### PR TITLE
JSON Schema validation (community opinion wanted)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-async-local-storage",
-  "version": "3.0.0",
+  "version": "3.1.0-beta.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -110,16 +110,6 @@
       "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
       "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8=",
       "dev": true
-    },
-    "ajv": {
-      "version": "4.11.8",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-      "dev": true,
-      "requires": {
-        "co": "4.6.0",
-        "json-stable-stringify": "1.0.1"
-      }
     },
     "align-text": {
       "version": "0.1.4",
@@ -3582,6 +3572,18 @@
       "requires": {
         "ajv": "4.11.8",
         "har-schema": "1.0.5"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "4.11.8",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+          "dev": true,
+          "requires": {
+            "co": "4.6.0",
+            "json-stable-stringify": "1.0.1"
+          }
+        }
       }
     },
     "has-ansi": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-async-local-storage",
-  "version": "3.1.0-beta.2",
+  "version": "3.1.0-beta.3",
   "description": "Efficient local storage module for Angular : simple API based on native localStorage API, but internally stored via the asynchronous IndexedDB API for performance, and wrapped in RxJS observables to be homogeneous with other Angular modules.",
   "main": "./bundles/angular-async-local-storage.umd.js",
   "module": "./angular-async-local-storage.es5.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-async-local-storage",
-  "version": "3.0.0",
+  "version": "3.1.0-beta.2",
   "description": "Efficient local storage module for Angular : simple API based on native localStorage API, but internally stored via the asynchronous IndexedDB API for performance, and wrapped in RxJS observables to be homogeneous with other Angular modules.",
   "main": "./bundles/angular-async-local-storage.umd.js",
   "module": "./angular-async-local-storage.es5.js",
@@ -54,6 +54,7 @@
     "lint": "tslint ./src/**/*.ts -t verbose",
     "release": "standard-version"
   },
+  "dependencies": {},
   "peerDependencies": {
     "@angular/core": ">=5.0.0 <6.0.0",
     "@angular/common": ">=5.0.0 <6.0.0",

--- a/src/demo/app/app.component.ts
+++ b/src/demo/app/app.component.ts
@@ -33,9 +33,9 @@ export class AppComponent implements OnInit {
 
         });
 
-        this.localStorage.getItem<User>('user', { schema: { type: 'string' } }).subscribe((data) => {
+        this.localStorage.getItem<User>('user', { schema: { type: 'string' } }).subscribe(() => {}, () => {
 
-          this.validation = data ? data.name : 'Schema invalid';
+          this.validation = 'Schema invalid';
 
         });
 

--- a/src/demo/app/app.component.ts
+++ b/src/demo/app/app.component.ts
@@ -7,11 +7,15 @@ interface User {
 
 @Component({
   selector: 'demo-app',
-  template: `<p>Should display 'Homer Simpsons' : {{name}}</p>`
+  template: `
+    <p>Should display 'Homer Simpsons' : {{name}}</p>
+    <p>Should display 'Schema invalid' : {{validation}}</p>
+  `
 })
 export class AppComponent implements OnInit {
 
   name: string;
+  validation: string;
 
   constructor(protected localStorage: AsyncLocalStorage) {}
 
@@ -26,6 +30,12 @@ export class AppComponent implements OnInit {
         this.localStorage.getItem<User>('user').subscribe((data) => {
 
           this.name = data ? data.name : '';
+
+        });
+
+        this.localStorage.getItem<User>('user', { schema: { type: 'string' } }).subscribe((data) => {
+
+          this.validation = data ? data.name : 'Schema invalid';
 
         });
 

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,3 +1,3 @@
 export { AsyncLocalStorage } from './src/service/lib.service';
 export { AsyncLocalStorageModule } from './src/module';
-export { JSONSchema } from './src/service/validation/index';
+export { JSONSchema, JSONSchemaType } from './src/service/validation/index';

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,3 +1,3 @@
 export { JSONSchema, JSONSchemaType } from './src/service/validation/json-schema';
-export { AsyncLocalStorage, ALSGetItemOptions } from './src/service/lib.service';
+export { ALSGetItemOptions, AsyncLocalStorage } from './src/service/lib.service';
 export { AsyncLocalStorageModule } from './src/module';

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,3 +1,3 @@
-export { AsyncLocalStorage } from './src/service/lib.service';
+export { JSONSchema, JSONSchemaType } from './src/service/validation/json-schema';
+export { AsyncLocalStorage, ALSGetItemOptions } from './src/service/lib.service';
 export { AsyncLocalStorageModule } from './src/module';
-export { JSONSchema, JSONSchemaType } from './src/service/validation/index';

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,2 +1,3 @@
 export { AsyncLocalStorage } from './src/service/lib.service';
 export { AsyncLocalStorageModule } from './src/module';
+export { JSONSchema } from './src/service/validation/index';

--- a/src/lib/src/module.ts
+++ b/src/lib/src/module.ts
@@ -3,7 +3,10 @@ import { isPlatformBrowser } from '@angular/common';
 
 import { JSONValidator } from './service/validation/json-validator';
 import { AsyncLocalStorage } from './service/lib.service';
-import { AsyncLocalDatabase, IndexedDBDatabase, LocalStorageDatabase, MockLocalDatabase } from './service/databases/index';
+import { AsyncLocalDatabase } from './service/databases/async-local-database';
+import { IndexedDBDatabase } from './service/databases/indexeddb-database';
+import { LocalStorageDatabase } from './service/databases/localstorage-database';
+import { MockLocalDatabase } from './service/databases/mock-local-database';
 
 export function asyncLocalStorageFactory(platformId: Object, jsonValidator: JSONValidator) {
 

--- a/src/lib/src/module.ts
+++ b/src/lib/src/module.ts
@@ -3,25 +3,26 @@ import { isPlatformBrowser } from '@angular/common';
 
 import { AsyncLocalStorage } from './service/lib.service';
 import { AsyncLocalDatabase, IndexedDBDatabase, LocalStorageDatabase, MockLocalDatabase } from './service/databases/index';
+import { JSONValidator } from './service/validation/index';
 
-export function asyncLocalStorageFactory(platformId: Object) {
+export function asyncLocalStorageFactory(platformId: Object, jsonValidator: JSONValidator) {
 
   let database: AsyncLocalDatabase;
 
   if (isPlatformBrowser(platformId) && ('indexedDB' in window)) {
 
     /* Try with IndexedDB in modern browsers */
-    database = new IndexedDBDatabase();
+    database = new IndexedDBDatabase(jsonValidator);
 
   } else if (isPlatformBrowser(platformId) && ('localStorage' in window)) {
 
     /* Try with localStorage in old browsers (IE9) */
-    database = new LocalStorageDatabase();
+    database = new LocalStorageDatabase(jsonValidator);
 
   } else {
 
     /* Fake database for server-side rendering (Universal) */
-    database = new MockLocalDatabase();
+    database = new MockLocalDatabase(jsonValidator);
 
   }
 
@@ -34,8 +35,9 @@ export function asyncLocalStorageFactory(platformId: Object) {
     {
       provide: AsyncLocalStorage,
       useFactory: asyncLocalStorageFactory,
-      deps: [PLATFORM_ID]
-    }
+      deps: [PLATFORM_ID, JSONValidator]
+    },
+    JSONValidator
   ]
 })
 export class AsyncLocalStorageModule { }

--- a/src/lib/src/module.ts
+++ b/src/lib/src/module.ts
@@ -1,7 +1,7 @@
 import { NgModule, PLATFORM_ID } from '@angular/core';
 import { isPlatformBrowser } from '@angular/common';
 
-import { JSONValidator } from './service/validation/index';
+import { JSONValidator } from './service/validation/json-validator';
 import { AsyncLocalStorage } from './service/lib.service';
 import { AsyncLocalDatabase, IndexedDBDatabase, LocalStorageDatabase, MockLocalDatabase } from './service/databases/index';
 
@@ -12,21 +12,21 @@ export function asyncLocalStorageFactory(platformId: Object, jsonValidator: JSON
   if (isPlatformBrowser(platformId) && ('indexedDB' in window)) {
 
     /* Try with IndexedDB in modern browsers */
-    database = new IndexedDBDatabase(jsonValidator);
+    database = new IndexedDBDatabase();
 
   } else if (isPlatformBrowser(platformId) && ('localStorage' in window)) {
 
     /* Try with localStorage in old browsers (IE9) */
-    database = new LocalStorageDatabase(jsonValidator);
+    database = new LocalStorageDatabase();
 
   } else {
 
     /* Fake database for server-side rendering (Universal) */
-    database = new MockLocalDatabase(jsonValidator);
+    database = new MockLocalDatabase();
 
   }
 
-  return new AsyncLocalStorage(database);
+  return new AsyncLocalStorage(database, jsonValidator);
 
 };
 

--- a/src/lib/src/module.ts
+++ b/src/lib/src/module.ts
@@ -1,9 +1,9 @@
 import { NgModule, PLATFORM_ID } from '@angular/core';
 import { isPlatformBrowser } from '@angular/common';
 
+import { JSONValidator } from './service/validation/index';
 import { AsyncLocalStorage } from './service/lib.service';
 import { AsyncLocalDatabase, IndexedDBDatabase, LocalStorageDatabase, MockLocalDatabase } from './service/databases/index';
-import { JSONValidator } from './service/validation/index';
 
 export function asyncLocalStorageFactory(platformId: Object, jsonValidator: JSONValidator) {
 
@@ -32,12 +32,12 @@ export function asyncLocalStorageFactory(platformId: Object, jsonValidator: JSON
 
 @NgModule({
   providers: [
+    JSONValidator,
     {
       provide: AsyncLocalStorage,
       useFactory: asyncLocalStorageFactory,
       deps: [PLATFORM_ID, JSONValidator]
     },
-    JSONValidator
   ]
 })
-export class AsyncLocalStorageModule { }
+export class AsyncLocalStorageModule {}

--- a/src/lib/src/service/databases/async-local-database.ts
+++ b/src/lib/src/service/databases/async-local-database.ts
@@ -1,10 +1,6 @@
 import { Observable } from 'rxjs/Observable';
 
-import { JSONSchema } from '../validation/index';
-
-export interface GetItemOptions {
-  schema?: JSONSchema | null;
-}
+import { ALSGetItemOptions } from '../lib.service';
 
 export abstract class AsyncLocalDatabase {
 
@@ -12,7 +8,7 @@ export abstract class AsyncLocalDatabase {
     schema: null
   };
 
-  abstract getItem<T = any>(key: string, options?: GetItemOptions): Observable<T | null>;
+  abstract getItem<T = any>(key: string, options?: ALSGetItemOptions): Observable<T | null>;
   abstract setItem(key: string, data: any): Observable<boolean>;
   abstract removeItem(key: string): Observable<boolean>;
   abstract clear(): Observable<boolean>;

--- a/src/lib/src/service/databases/async-local-database.ts
+++ b/src/lib/src/service/databases/async-local-database.ts
@@ -1,14 +1,8 @@
 import { Observable } from 'rxjs/Observable';
 
-import { ALSGetItemOptions } from '../lib.service';
-
 export abstract class AsyncLocalDatabase {
 
-  protected readonly getItemOptionsDefault = {
-    schema: null
-  };
-
-  abstract getItem<T = any>(key: string, options?: ALSGetItemOptions): Observable<T | null>;
+  abstract getItem<T = any>(key: string): Observable<T | null>;
   abstract setItem(key: string, data: any): Observable<boolean>;
   abstract removeItem(key: string): Observable<boolean>;
   abstract clear(): Observable<boolean>;

--- a/src/lib/src/service/databases/async-local-database.ts
+++ b/src/lib/src/service/databases/async-local-database.ts
@@ -1,8 +1,20 @@
 import { Observable } from 'rxjs/Observable';
 
+import { JSONSchema } from '../validation/index';
+
+export interface GetItemOptions {
+  schema?: JSONSchema | null;
+}
+
 export abstract class AsyncLocalDatabase {
-  abstract getItem<T = any>(key: string): Observable<T | null>;
+
+  protected readonly getItemOptionsDefault = {
+    schema: null
+  };
+
+  abstract getItem<T = any>(key: string, options?: GetItemOptions): Observable<T | null>;
   abstract setItem(key: string, data: any): Observable<boolean>;
   abstract removeItem(key: string): Observable<boolean>;
   abstract clear(): Observable<boolean>;
+
 }

--- a/src/lib/src/service/databases/index.ts
+++ b/src/lib/src/service/databases/index.ts
@@ -1,4 +1,0 @@
-export { AsyncLocalDatabase } from './async-local-database';
-export { IndexedDBDatabase } from './indexeddb-database';
-export { LocalStorageDatabase } from './localstorage-database';
-export { MockLocalDatabase } from './mock-local-database';

--- a/src/lib/src/service/databases/index.ts
+++ b/src/lib/src/service/databases/index.ts
@@ -1,4 +1,4 @@
-export { AsyncLocalDatabase } from './async-local-database';
+export { AsyncLocalDatabase, GetItemOptions } from './async-local-database';
 export { IndexedDBDatabase } from './indexeddb-database';
 export { LocalStorageDatabase } from './localstorage-database';
 export { MockLocalDatabase } from './mock-local-database';

--- a/src/lib/src/service/databases/index.ts
+++ b/src/lib/src/service/databases/index.ts
@@ -1,4 +1,4 @@
-export { AsyncLocalDatabase, GetItemOptions } from './async-local-database';
+export { AsyncLocalDatabase } from './async-local-database';
 export { IndexedDBDatabase } from './indexeddb-database';
 export { LocalStorageDatabase } from './localstorage-database';
 export { MockLocalDatabase } from './mock-local-database';

--- a/src/lib/src/service/databases/indexeddb-database.ts
+++ b/src/lib/src/service/databases/indexeddb-database.ts
@@ -8,8 +8,9 @@ import { of as observableOf }  from 'rxjs/observable/of';
 import { _throw as observableThrow } from 'rxjs/observable/throw';
 import { race as observableRace }  from 'rxjs/observable/race';
 
-import { AsyncLocalDatabase, GetItemOptions } from './async-local-database';
-import { JSONValidator } from '../validation/index';
+import { AsyncLocalDatabase } from './async-local-database';
+import { ALSGetItemOptions } from '../lib.service';
+import { JSONValidator } from '../validation/json-validator';
 
 @Injectable()
 export class IndexedDBDatabase extends AsyncLocalDatabase {
@@ -56,7 +57,7 @@ export class IndexedDBDatabase extends AsyncLocalDatabase {
    * @param key The item's key
    * @returns The item's value if the key exists, null otherwise, wrapped in an RxJS Observable
    */
-  getItem<T = any>(key: string, options: GetItemOptions = this.getItemOptionsDefault) {
+  getItem<T = any>(key: string, options: ALSGetItemOptions = this.getItemOptionsDefault) {
 
     /* Opening a trasaction and requesting the item in local storage */
     return this.transaction().pipe(

--- a/src/lib/src/service/databases/indexeddb-database.ts
+++ b/src/lib/src/service/databases/indexeddb-database.ts
@@ -9,8 +9,6 @@ import { _throw as observableThrow } from 'rxjs/observable/throw';
 import { race as observableRace }  from 'rxjs/observable/race';
 
 import { AsyncLocalDatabase } from './async-local-database';
-import { ALSGetItemOptions } from '../lib.service';
-import { JSONValidator } from '../validation/json-validator';
 
 @Injectable()
 export class IndexedDBDatabase extends AsyncLocalDatabase {
@@ -40,7 +38,7 @@ export class IndexedDBDatabase extends AsyncLocalDatabase {
   /**
    * Connects to IndexedDB
    */
-  constructor(protected jsonValidator: JSONValidator) {
+  constructor() {
 
     super();
 
@@ -57,7 +55,7 @@ export class IndexedDBDatabase extends AsyncLocalDatabase {
    * @param key The item's key
    * @returns The item's value if the key exists, null otherwise, wrapped in an RxJS Observable
    */
-  getItem<T = any>(key: string, options: ALSGetItemOptions = this.getItemOptionsDefault) {
+  getItem<T = any>(key: string) {
 
     /* Opening a trasaction and requesting the item in local storage */
     return this.transaction().pipe(
@@ -67,9 +65,7 @@ export class IndexedDBDatabase extends AsyncLocalDatabase {
         /* Listening to the success event, and passing the item value if found, null otherwise */
         const success = (observableFromEvent(request, 'success') as Observable<Event>).pipe(
           map((event) => (event.target as IDBRequest).result),
-          map((result) => result && (this.dataPath in result) ? (result[this.dataPath] as T) : null),
-          /* Validate data upon a json schema if requested */
-          map((data) => !options.schema || this.jsonValidator.validate(data, options.schema) ? data : null)
+          map((result) => result && (this.dataPath in result) ? (result[this.dataPath] as T) : null)
         );
 
         /* Merging success and errors events and autoclosing the observable */

--- a/src/lib/src/service/databases/localstorage-database.ts
+++ b/src/lib/src/service/databases/localstorage-database.ts
@@ -4,8 +4,9 @@ import { map } from 'rxjs/operators';
 import { of as observableOf } from 'rxjs/observable/of';
 import { _throw as observableThrow } from 'rxjs/observable/throw';
 
-import { AsyncLocalDatabase, GetItemOptions } from './async-local-database';
-import { JSONValidator } from '../validation/index';
+import { AsyncLocalDatabase } from './async-local-database';
+import { ALSGetItemOptions } from '../lib.service';
+import { JSONValidator } from '../validation/json-validator';
 
 @Injectable()
 export class LocalStorageDatabase extends AsyncLocalDatabase {
@@ -24,7 +25,7 @@ export class LocalStorageDatabase extends AsyncLocalDatabase {
    * @param key The item's key
    * @returns The item's value if the key exists, null otherwise, wrapped in an RxJS Observable
    */
-  getItem<T = any>(key: string, options: GetItemOptions = this.getItemOptionsDefault): Observable<T | null> {
+  getItem<T = any>(key: string, options: ALSGetItemOptions = this.getItemOptionsDefault): Observable<T | null> {
 
     const unparsedData = this.localStorage.getItem(key);
     let parsedData: T | null = null;

--- a/src/lib/src/service/databases/localstorage-database.ts
+++ b/src/lib/src/service/databases/localstorage-database.ts
@@ -5,8 +5,6 @@ import { of as observableOf } from 'rxjs/observable/of';
 import { _throw as observableThrow } from 'rxjs/observable/throw';
 
 import { AsyncLocalDatabase } from './async-local-database';
-import { ALSGetItemOptions } from '../lib.service';
-import { JSONValidator } from '../validation/json-validator';
 
 @Injectable()
 export class LocalStorageDatabase extends AsyncLocalDatabase {
@@ -14,18 +12,12 @@ export class LocalStorageDatabase extends AsyncLocalDatabase {
   /* Initializing native localStorage right now to be able to check its support on class instanciation */
   protected localStorage = localStorage;
 
-  constructor(protected jsonValidator: JSONValidator) {
-
-    super();
-
-  }
-
   /**
    * Gets an item value in local storage
    * @param key The item's key
    * @returns The item's value if the key exists, null otherwise, wrapped in an RxJS Observable
    */
-  getItem<T = any>(key: string, options: ALSGetItemOptions = this.getItemOptionsDefault): Observable<T | null> {
+  getItem<T = any>(key: string): Observable<T | null> {
 
     const unparsedData = this.localStorage.getItem(key);
     let parsedData: T | null = null;
@@ -40,12 +32,7 @@ export class LocalStorageDatabase extends AsyncLocalDatabase {
 
     }
 
-    const observableData = observableOf(parsedData).pipe(
-      /* Validate data upon a json schema if requested */
-      map((data) => !options.schema || this.jsonValidator.validate(data, options.schema) ? data : null)
-    );
-
-    return observableData;
+    return observableOf(parsedData);
 
   }
 

--- a/src/lib/src/service/databases/mock-local-database.ts
+++ b/src/lib/src/service/databases/mock-local-database.ts
@@ -4,35 +4,22 @@ import { map } from 'rxjs/operators';
 import { of as observableOf } from 'rxjs/observable/of';
 
 import { AsyncLocalDatabase } from './async-local-database';
-import { ALSGetItemOptions } from '../lib.service';
-import { JSONValidator } from '../validation/json-validator';
 
 @Injectable()
 export class MockLocalDatabase extends AsyncLocalDatabase {
 
   protected localStorage = new Map<string, any>();
 
-  constructor(protected jsonValidator: JSONValidator) {
-
-    super();
-
-  }
-
   /**
    * Gets an item value in local storage
    * @param key The item's key
    * @returns The item's value if the key exists, null otherwise, wrapped in an RxJS Observable
    */
-   getItem<T = any>(key: string, options: ALSGetItemOptions = this.getItemOptionsDefault) {
+   getItem<T = any>(key: string) {
 
     const rawData: T | null = this.localStorage.get(key);
 
-    const observableData = observableOf((rawData !== undefined) ? rawData : null).pipe(
-      /* Validate data upon a json schema if requested */
-      map((data) => !options.schema || this.jsonValidator.validate(data, options.schema) ? data : null)
-    );
-
-    return observableData;
+    return observableOf((rawData !== undefined) ? rawData : null);
 
   }
 

--- a/src/lib/src/service/databases/mock-local-database.ts
+++ b/src/lib/src/service/databases/mock-local-database.ts
@@ -3,8 +3,9 @@ import { Observable } from 'rxjs/Observable';
 import { map } from 'rxjs/operators';
 import { of as observableOf } from 'rxjs/observable/of';
 
-import { AsyncLocalDatabase, GetItemOptions } from './async-local-database';
-import { JSONValidator } from '../validation/index';
+import { AsyncLocalDatabase } from './async-local-database';
+import { ALSGetItemOptions } from '../lib.service';
+import { JSONValidator } from '../validation/json-validator';
 
 @Injectable()
 export class MockLocalDatabase extends AsyncLocalDatabase {
@@ -22,7 +23,7 @@ export class MockLocalDatabase extends AsyncLocalDatabase {
    * @param key The item's key
    * @returns The item's value if the key exists, null otherwise, wrapped in an RxJS Observable
    */
-   getItem<T = any>(key: string, options: GetItemOptions = this.getItemOptionsDefault) {
+   getItem<T = any>(key: string, options: ALSGetItemOptions = this.getItemOptionsDefault) {
 
     const rawData: T | null = this.localStorage.get(key);
 

--- a/src/lib/src/service/databases/mock-local-database.ts
+++ b/src/lib/src/service/databases/mock-local-database.ts
@@ -1,25 +1,37 @@
 import { Injectable } from '@angular/core';
-
 import { Observable } from 'rxjs/Observable';
+import { map } from 'rxjs/operators';
 import { of as observableOf } from 'rxjs/observable/of';
 
-import { AsyncLocalDatabase } from './async-local-database';
+import { AsyncLocalDatabase, GetItemOptions } from './async-local-database';
+import { JSONValidator } from '../validation/index';
 
 @Injectable()
 export class MockLocalDatabase extends AsyncLocalDatabase {
 
   protected localStorage = new Map<string, any>();
 
+  constructor(protected jsonValidator: JSONValidator) {
+
+    super();
+
+  }
+
   /**
    * Gets an item value in local storage
    * @param key The item's key
    * @returns The item's value if the key exists, null otherwise, wrapped in an RxJS Observable
    */
-  public getItem<T = any>(key: string) {
+   getItem<T = any>(key: string, options: GetItemOptions = this.getItemOptionsDefault) {
 
-    let data: T | null = this.localStorage.get(key);
+    const rawData: T | null = this.localStorage.get(key);
 
-    return observableOf((data !== undefined) ? data : null);
+    const observableData = observableOf((rawData !== undefined) ? rawData : null).pipe(
+      /* Validate data upon a json schema if requested */
+      map((data) => !options.schema || this.jsonValidator.validate(data, options.schema) ? data : null)
+    );
+
+    return observableData;
 
   }
 
@@ -29,7 +41,7 @@ export class MockLocalDatabase extends AsyncLocalDatabase {
    * @param data The item's value, must NOT be null or undefined
    * @returns An RxJS Observable to wait the end of the operation
    */
-  public setItem(key: string, data: any) {
+   setItem(key: string, data: any) {
 
     this.localStorage.set(key, data);
 
@@ -42,7 +54,7 @@ export class MockLocalDatabase extends AsyncLocalDatabase {
    * @param key The item's key
    * @returns An RxJS Observable to wait the end of the operation
    */
-  public removeItem(key: string) {
+   removeItem(key: string) {
 
     this.localStorage.delete(key);
 
@@ -54,7 +66,7 @@ export class MockLocalDatabase extends AsyncLocalDatabase {
    * Deletes all items from local storage
    * @returns An RxJS Observable to wait the end of the operation
    */
-  public clear() {
+   clear() {
 
     this.localStorage.clear();
 

--- a/src/lib/src/service/lib.service.spec.ts
+++ b/src/lib/src/service/lib.service.spec.ts
@@ -2,8 +2,11 @@ import { TestBed, inject, async } from '@angular/core/testing';
 import { map } from 'rxjs/operators';
 
 import { AsyncLocalStorage } from './lib.service';
-import { IndexedDBDatabase, LocalStorageDatabase, MockLocalDatabase } from './databases/index';
-import { JSONSchema, JSONValidator } from './validation/index';
+import { IndexedDBDatabase } from './databases/indexeddb-database';
+import { LocalStorageDatabase } from './databases/localstorage-database';
+import { MockLocalDatabase } from './databases/mock-local-database';
+import { JSONSchema } from './validation/json-schema';
+import { JSONValidator } from './validation/json-validator';
 
 function testGetItem<T>(type: 'primitive' | 'object', localStorage: AsyncLocalStorage, value: T, done: DoneFn) {
 

--- a/src/lib/src/service/lib.service.spec.ts
+++ b/src/lib/src/service/lib.service.spec.ts
@@ -214,7 +214,7 @@ function tests(localStorage: AsyncLocalStorage) {
 
 describe('AsyncLocalStorage with mock storage', () => {
 
-  let localStorage = new AsyncLocalStorage(new MockLocalDatabase(new JSONValidator()));
+  let localStorage = new AsyncLocalStorage(new MockLocalDatabase(), new JSONValidator());
 
   tests(localStorage);
 
@@ -222,7 +222,7 @@ describe('AsyncLocalStorage with mock storage', () => {
 
 describe('AsyncLocalStorage with localStorage', () => {
 
-  let localStorage = new AsyncLocalStorage(new LocalStorageDatabase(new JSONValidator()));
+  let localStorage = new AsyncLocalStorage(new LocalStorageDatabase(), new JSONValidator());
 
   tests(localStorage);
 
@@ -230,7 +230,7 @@ describe('AsyncLocalStorage with localStorage', () => {
 
 describe('AsyncLocalStorage with IndexedDB', () => {
 
-  let localStorage = new AsyncLocalStorage(new IndexedDBDatabase(new JSONValidator()));
+  let localStorage = new AsyncLocalStorage(new IndexedDBDatabase, new JSONValidator());
 
   tests(localStorage);
 

--- a/src/lib/src/service/lib.service.spec.ts
+++ b/src/lib/src/service/lib.service.spec.ts
@@ -155,7 +155,7 @@ function tests(localStorage: AsyncLocalStorage) {
 
   });
 
-  it('should return null if JSON schema is invalid', (done: DoneFn) => {
+  it('should call error callback if data is invalid against JSON schema', (done: DoneFn) => {
 
     const index = 'index';
     const value = {
@@ -174,7 +174,41 @@ function tests(localStorage: AsyncLocalStorage) {
 
       localStorage.getItem<{ expected: string }>(index, { schema }).subscribe((data) => {
 
-        expect(data).toBeNull();
+        fail();
+
+        done();
+
+      }, (error) => {
+
+        expect(error.message).toBe(`JSON invalid`);
+
+        done();
+
+      });
+
+    });
+
+  });
+
+  it('should call error callback if the JSON schema itself is invalid', (done: DoneFn) => {
+
+    const index = 'doesnotmatter';
+    const value = 'doesnotmatter';
+    const schema: JSONSchema = {
+      required: ['expected']
+    };
+
+    localStorage.setItem(index, value).subscribe(() => {
+
+      localStorage.getItem(index, { schema }).subscribe((data) => {
+
+        fail();
+
+        done();
+
+      }, (error) => {
+
+        expect(error).toBeTruthy();
 
         done();
 
@@ -207,7 +241,40 @@ function tests(localStorage: AsyncLocalStorage) {
 
         done();
 
+      }, () => {
+
+        fail();
+
+        done();
+
       });
+
+    });
+
+  });
+
+  it('should return the data if the data is null (no validation)', (done: DoneFn) => {
+
+    const schema: JSONSchema = {
+      properties: {
+        expected: {
+          type: 'string'
+        }
+      },
+      required: ['expected']
+    };
+
+    localStorage.getItem<{ expected: string }>('notexisting', { schema }).subscribe((data) => {
+
+      expect((data)).toBeNull();
+
+      done();
+
+    }, () => {
+
+      fail();
+
+      done();
 
     });
 

--- a/src/lib/src/service/lib.service.ts
+++ b/src/lib/src/service/lib.service.ts
@@ -2,7 +2,7 @@ import { Inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 import { map } from 'rxjs/operators';
 
-import { AsyncLocalDatabase } from './databases/index';
+import { AsyncLocalDatabase } from './databases/async-local-database';
 import { JSONSchema } from './validation/json-schema';
 import { JSONValidator } from './validation/json-validator';
 

--- a/src/lib/src/service/lib.service.ts
+++ b/src/lib/src/service/lib.service.ts
@@ -1,7 +1,7 @@
 import { Inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 
-import { AsyncLocalDatabase } from './databases/async-local-database';
+import { AsyncLocalDatabase, GetItemOptions } from './databases/index';
 
 @Injectable()
 export class AsyncLocalStorage {
@@ -11,7 +11,7 @@ export class AsyncLocalStorage {
   /**
    * Injects a local database
    */
-  public constructor(database: AsyncLocalDatabase) {
+  constructor(database: AsyncLocalDatabase) {
 
     this.database = database;
 
@@ -22,9 +22,9 @@ export class AsyncLocalStorage {
    * @param key The item's key
    * @returns The item's value if the key exists, null otherwise, wrapped in an RxJS Observable
    */
-  public getItem<T = any>(key: string) {
+  getItem<T = any>(key: string, options?: GetItemOptions) {
 
-    return this.database.getItem<T>(key);
+    return this.database.getItem<T>(key, options);
 
   }
 
@@ -34,7 +34,7 @@ export class AsyncLocalStorage {
    * @param data The item's value, must NOT be null or undefined
    * @returns An RxJS Observable to wait the end of the operation
    */
-  public setItem(key: string, data: any) {
+   setItem(key: string, data: any) {
 
     return this.database.setItem(key, data);
 
@@ -45,7 +45,7 @@ export class AsyncLocalStorage {
    * @param key The item's key
    * @returns An RxJS Observable to wait the end of the operation
    */
-  public removeItem(key: string) {
+   removeItem(key: string) {
 
     return this.database.removeItem(key);
 
@@ -55,7 +55,7 @@ export class AsyncLocalStorage {
    * Deletes all items from local storage
    * @returns An RxJS Observable to wait the end of the operation
    */
-  public clear() {
+   clear() {
 
     return this.database.clear();
 

--- a/src/lib/src/service/lib.service.ts
+++ b/src/lib/src/service/lib.service.ts
@@ -1,7 +1,12 @@
 import { Inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 
-import { AsyncLocalDatabase, GetItemOptions } from './databases/index';
+import { AsyncLocalDatabase } from './databases/index';
+import { JSONSchema } from './validation/json-schema';
+
+export interface ALSGetItemOptions {
+  schema?: JSONSchema | null;
+}
 
 @Injectable()
 export class AsyncLocalStorage {
@@ -22,7 +27,7 @@ export class AsyncLocalStorage {
    * @param key The item's key
    * @returns The item's value if the key exists, null otherwise, wrapped in an RxJS Observable
    */
-  getItem<T = any>(key: string, options?: GetItemOptions) {
+  getItem<T = any>(key: string, options?: ALSGetItemOptions) {
 
     return this.database.getItem<T>(key, options);
 

--- a/src/lib/src/service/validation/index.ts
+++ b/src/lib/src/service/validation/index.ts
@@ -1,2 +1,2 @@
-export { JSONSchema } from './json-schema';
+export { JSONSchema, JSONSchemaType } from './json-schema';
 export { JSONValidator } from './json-validator';

--- a/src/lib/src/service/validation/index.ts
+++ b/src/lib/src/service/validation/index.ts
@@ -1,2 +1,0 @@
-export { JSONSchema, JSONSchemaType } from './json-schema';
-export { JSONValidator } from './json-validator';

--- a/src/lib/src/service/validation/index.ts
+++ b/src/lib/src/service/validation/index.ts
@@ -1,0 +1,2 @@
+export { JSONSchema } from './json-schema';
+export { JSONValidator } from './json-validator';

--- a/src/lib/src/service/validation/json-schema.ts
+++ b/src/lib/src/service/validation/json-schema.ts
@@ -1,30 +1,26 @@
 /**
+ * Types allowed in a JSON Schema
+ */
+export type JSONSchemaType = 'string' | 'number' | 'integer' | 'boolean' | 'array' | 'object' | 'null';
+
+/**
  * Subset of the JSON Schema draft 6.
- * Not all features are supported : just follow the interface and it will be OK.
- * Unlike the spec, a value MUST have either 'type' or 'properties' (to enforce strict types).
+ * Types are enforced to validate everything : each value MUST have either 'type' or 'properties' or 'items'.
+ * Therefore, unlike the spec, booleans are not allowed as schemas.
+ * @todo Not all validation features are supported yet : just follow the interface.
  */
 export interface JSONSchema {
 
   /**
-   * Type for a value.
-   * Not required for objects, just set 'properties' and/or 'required'.
+   * Type for a primitive value.
+   * Not required for objects, just set 'properties'.
    * Not required for arrays, just set 'items'.
-   * Unlike spec, an array of types is not supported yet.
    * @see http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.25
    */
-  type?: 'string' | 'number' | 'integer' | 'boolean' | 'array' | 'object' | 'null';
+  type?: JSONSchemaType | JSONSchemaType[];
 
   /**
-   * Array of the names of the required properties for an object.
-   * Properties set as required should be present in 'properties' too (to enforce strict types).
-   * Note that in the last spec, booleans are not supported anymore.
-   * @see http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.17
-   */
-  required?: string[];
-
-  /**
-   * List of properties for an object.
-   * Unlike the spec, booleans are not supported (to enforce strict types).
+   * List of properties schemas for an object.
    * @see http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.18
    */
   properties?: {
@@ -32,10 +28,19 @@ export interface JSONSchema {
   };
 
   /**
-   * Schema to describe the values of the array.
-   * Unlike the spec, only one type is authorized (to enforce strict types).
+   * Array of names of the required properties for an object.
+   * Properties set as required should be present in 'properties' too.
+   * Note that in the last spec, booleans are not supported anymore.
+   * @see http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.17
    */
-  items?: JSONSchema;
+  required?: string[];
+
+  /**
+   * Schema for the values of an array.
+   * 'type' of values should be a string (not an array of type).
+   * @see http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.4.1
+   */
+  items?: JSONSchema | JSONSchema[];
 
   /**
    * Allow other properties, to not fail with existing JSON schemas.

--- a/src/lib/src/service/validation/json-schema.ts
+++ b/src/lib/src/service/validation/json-schema.ts
@@ -1,0 +1,45 @@
+/**
+ * Subset of the JSON Schema draft 6.
+ * Not all features are supported : just follow the interface and it will be OK.
+ * Unlike the spec, a value MUST have either 'type' or 'properties' (to enforce strict types).
+ */
+export interface JSONSchema {
+
+  /**
+   * Type for a value.
+   * Not required for objects, just set 'properties' and/or 'required'.
+   * Not required for arrays, just set 'items'.
+   * Unlike spec, an array of types is not supported yet.
+   * @see http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.25
+   */
+  type?: 'string' | 'number' | 'integer' | 'boolean' | 'array' | 'object' | 'null';
+
+  /**
+   * Array of the names of the required properties for an object.
+   * Properties set as required should be present in 'properties' too (to enforce strict types).
+   * Note that in the last spec, booleans are not supported anymore.
+   * @see http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.17
+   */
+  required?: string[];
+
+  /**
+   * List of properties for an object.
+   * Unlike the spec, booleans are not supported (to enforce strict types).
+   * @see http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.18
+   */
+  properties?: {
+    [k: string]: JSONSchema;
+  };
+
+  /**
+   * Schema to describe the values of the array.
+   * Unlike the spec, only one type is authorized (to enforce strict types).
+   */
+  items?: JSONSchema;
+
+  /**
+   * Allow other properties, to not fail with existing JSON schemas.
+   */
+  [k: string]: any;
+
+}

--- a/src/lib/src/service/validation/json-validation.spec.ts
+++ b/src/lib/src/service/validation/json-validation.spec.ts
@@ -1,0 +1,401 @@
+import { JSONValidator } from './json-validator';
+
+describe(`JSONValidator`, () => {
+
+  let jsonValidator: JSONValidator;
+
+  beforeEach(() => {
+
+    jsonValidator = new JSONValidator();
+
+  });
+
+  describe(`validation`, () => {
+
+    it(`should throw if schema is not an object`, () => {
+
+      expect(() => {
+        jsonValidator.validate('test', 'test' as any);
+      }).toThrowError();
+
+    });
+
+    it(`should throw if nothing describes the value`, () => {
+
+      expect(() => {
+        jsonValidator.validate('test', {});
+      }).toThrowError();
+
+    });
+
+  });
+
+  describe(`validateType`, () => {
+
+    it(`should throw if type is not a string`, () => {
+
+      expect(() => {
+        jsonValidator.validate('test', { type: 10 as any });
+      }).toThrowError();
+
+    });
+
+    it(`should return true on a string value with string type`, () => {
+
+      const test = jsonValidator.validate('test', { type: 'string' });
+
+      expect(test).toBe(true);
+
+    });
+
+    it(`should return true on an integer value with a number type`, () => {
+
+      const test = jsonValidator.validate(10, { type: 'number' });
+
+      expect(test).toBe(true);
+
+    });
+
+    it(`should return true on a decimal value with a number type`, () => {
+
+      const test = jsonValidator.validate(10.1, { type: 'number' });
+
+      expect(test).toBe(true);
+
+    });
+
+    it(`should return true on an integer value with an integer type`, () => {
+
+      const test = jsonValidator.validate(10, { type: 'integer' });
+
+      expect(test).toBe(true);
+
+    });
+
+    it(`should return false on a decimal value with an integer type`, () => {
+
+      const test = jsonValidator.validate(10.1, { type: 'integer' });
+
+      expect(test).toBe(false);
+
+    });
+
+    it(`should return true on a true value with a boolean type`, () => {
+
+      const test = jsonValidator.validate(true, { type: 'boolean' });
+
+      expect(test).toBe(true);
+
+    });
+
+    it(`should return true on a false value with a boolean type`, () => {
+
+      const test = jsonValidator.validate(false, { type: 'boolean' });
+
+      expect(test).toBe(true);
+
+    });
+
+    it(`should throw on an object value with an object type without 'properties'`, () => {
+
+      expect(() => {
+        jsonValidator.validate({}, { type: 'object' });
+      }).toThrow();
+
+    });
+
+    it(`should throw on an array value with an array type without 'items'`, () => {
+
+      expect(() => {
+        jsonValidator.validate({}, { type: 'array' });
+      }).toThrow();
+
+    });
+
+    it(`should return true on a null value with a null type`, () => {
+
+      const test = jsonValidator.validate(null, { type: 'null' });
+
+      expect(test).toBe(true);
+
+    });
+
+    it(`should return false on a primitive value with a mismatched type`, () => {
+
+      const test = jsonValidator.validate('test', { type: 'number' });
+
+      expect(test).toBe(false);
+
+    });
+
+  });
+
+  describe(`validateRequired`, () => {
+
+    it(`should return false if data is not an object`, () => {
+
+      const test = jsonValidator.validate('', { required: [], properties: {} });
+
+      expect(test).toBe(false);
+
+    });
+
+    it(`should throw if required list is not an array`, () => {
+
+      expect(() => {
+        jsonValidator.validate({}, { required: 10 as any, properties: {} });
+      }).toThrowError();
+
+    });
+
+    it(`should throw if required items are not strings`, () => {
+
+      expect(() => {
+        jsonValidator.validate({}, { required: [10] as any, properties: {} });
+      }).toThrowError();
+
+    });
+
+    it(`should throw if required properties are not described in 'properties'`, () => {
+
+      expect(() => {
+        jsonValidator.validate({ test: 'test' }, { required: ['test'] });
+      }).toThrowError();
+
+    });
+
+    it(`should return true on an object with the required properties`, () => {
+
+      const test = jsonValidator.validate({ test1: '', test2: '' }, {
+        required: ['test1', 'test2'],
+        properties: {
+          test1: { type: 'string' },
+          test2: { type: 'string' }
+        }
+      });
+
+      expect(test).toBe(true);
+
+    });
+
+    it(`should return true on an object with the required properties and others`, () => {
+
+      const test = jsonValidator.validate({ test1: '', test2: '', test3: '' }, {
+        required: ['test1', 'test2'],
+        properties: {
+          test1: { type: 'string' },
+          test2: { type: 'string' },
+          test3: { type: 'string' }
+        }
+      });
+
+      expect(test).toBe(true);
+
+    });
+
+    it(`should return false on an object with missing required properties`, () => {
+
+      const test = jsonValidator.validate({ test1: '' }, { required: ['test1', 'test2'],
+      properties: {
+        test1: { type: 'string' },
+        test2: { type: 'string' }
+      } });
+
+      expect(test).toBe(false);
+
+    });
+
+  });
+
+  describe(`validateProperties`, () => {
+
+    it(`should return false if data is not an object`, () => {
+
+      const test = jsonValidator.validate('', { properties: {} });
+
+      expect(test).toBe(false);
+
+    });
+
+    it(`should throw if properties list is not an object`, () => {
+
+      expect(() => {
+        jsonValidator.validate({}, { properties: 10 as any });
+      }).toThrowError();
+
+    });
+
+    it(`should return true on an object with valid properties`, () => {
+
+      const test = jsonValidator.validate({ test1: '', test2: 10 }, {
+        properties: {
+          test1: {
+            type: 'string'
+          },
+          test2: {
+            type: 'number'
+          }
+        }
+      });
+
+      expect(test).toBe(true);
+
+    });
+
+    it(`should return false on an object with invalid properties`, () => {
+
+      const test = jsonValidator.validate({ test1: 10, test2: 10 }, {
+        properties: {
+          test1: {
+            type: 'string'
+          },
+          test2: {
+            type: 'number'
+          }
+        }
+      });
+
+      expect(test).toBe(false);
+
+    });
+
+    it(`should return false on an object with too much properties`, () => {
+
+      const test = jsonValidator.validate({ test1: 10, test2: 10, test3: '' }, {
+        properties: {
+          test1: {
+            type: 'string'
+          },
+          test2: {
+            type: 'number'
+          }
+        }
+      });
+
+      expect(test).toBe(false);
+
+    });
+
+    it(`should return true on nested objects with valid properties`, () => {
+
+      const test = jsonValidator.validate({ test1: '', test2: { test3: 10 } }, {
+        properties: {
+          test1: {
+            type: 'string'
+          },
+          test2: {
+            properties: {
+              test3: {
+                type: 'number'
+              }
+            },
+            required: ['test3']
+          }
+        }
+      });
+
+      expect(test).toBe(true);
+
+    });
+
+    it(`should return false on nested objects with invalid properties`, () => {
+
+      const test = jsonValidator.validate({ test1: '', test2: { test3: '' } }, {
+        properties: {
+          test1: {
+            type: 'string'
+          },
+          test2: {
+            properties: {
+              test3: {
+                type: 'number'
+              }
+            },
+            required: ['test3']
+          }
+        }
+      });
+
+      expect(test).toBe(false);
+
+    });
+
+    it(`should return true with valid arrays nested in objects`, () => {
+
+      const test = jsonValidator.validate({ test: ['', ''] }, { properties: { test: { items: { type: 'string' } } } });
+
+      expect(test).toBe(true);
+
+    });
+
+  });
+
+  describe(`validateItems`, () => {
+
+    it(`should throw if items is not an object`, () => {
+
+      expect(() => {
+        jsonValidator.validate(['test'], { items: 10 as any });
+      }).toThrowError();
+
+    });
+
+    it(`should throw if items does not contain type`, () => {
+
+      expect(() => {
+        jsonValidator.validate(['test'], { items: {} });
+      }).toThrowError();
+
+    });
+
+    it(`should return false if data is not an array`, () => {
+
+      const test = jsonValidator.validate('', { items: { type: 'string' } });
+
+      expect(test).toBe(false);
+
+    });
+
+    it(`should return true if array items are valid`, () => {
+
+      const test = jsonValidator.validate(['', ''], { items: { type: 'string' } });
+
+      expect(test).toBe(true);
+
+    });
+
+    it(`should return false if array items are invalid`, () => {
+
+      const test = jsonValidator.validate(['', ''], { items: { type: 'number' } });
+
+      expect(test).toBe(false);
+
+    });
+
+    it(`should return true with valid nested arrays`, () => {
+
+      const test = jsonValidator.validate([[''], ['']], { items: { items: { type: 'string' } } });
+
+      expect(test).toBe(true);
+
+    });
+
+    it(`should return false with invalid nested arrays`, () => {
+
+      const test = jsonValidator.validate([[''], ['']], { items: { items: { type: 'number' } } });
+
+      expect(test).toBe(false);
+
+    });
+
+    it(`should return true with valid objects nested in arrays`, () => {
+
+      const test = jsonValidator.validate([{ test: 'test' }, [{ test: 'test' }]], { items: { properties: { test: { type: 'string' } } } });
+
+      expect(test).toBe(true);
+
+    });
+
+  });
+
+});

--- a/src/lib/src/service/validation/json-validation.spec.ts
+++ b/src/lib/src/service/validation/json-validation.spec.ts
@@ -130,6 +130,26 @@ describe(`JSONValidator`, () => {
 
   });
 
+  describe(`validateTypeList`, () => {
+
+    it(`should return true on a valid primitive value with an array type`, () => {
+
+      const test = jsonValidator.validate('test', { type: ['number', 'string'] });
+
+      expect(test).toBe(true);
+
+    });
+
+    it(`should return false on an invalid primitive value with an array type`, () => {
+
+      const test = jsonValidator.validate('test', { type: ['number', 'boolean'] });
+
+      expect(test).toBe(false);
+
+    });
+
+  });
+
   describe(`validateRequired`, () => {
 
     it(`should return false if data is not an object`, () => {
@@ -393,6 +413,34 @@ describe(`JSONValidator`, () => {
       const test = jsonValidator.validate([{ test: 'test' }, [{ test: 'test' }]], { items: { properties: { test: { type: 'string' } } } });
 
       expect(test).toBe(true);
+
+    });
+
+  });
+
+  describe(`validateItemsList`, () => {
+
+    it(`should return false if array length is not equel to schemas length`, () => {
+
+      const test = jsonValidator.validate(['', 10], { items: [{ type: 'string' }] });
+
+      expect(test).toBe(false);
+
+    });
+
+    it(`should return true if array values match schemas`, () => {
+
+      const test = jsonValidator.validate(['', 10], { items: [{ type: 'string' }, { type: 'number' }] });
+
+      expect(test).toBe(true);
+
+    });
+
+    it(`should return false if array values mismatch schemas`, () => {
+
+      const test = jsonValidator.validate(['', 10], { items: [{ type: 'string' }, { type: 'boolean' }] });
+
+      expect(test).toBe(false);
 
     });
 

--- a/src/lib/src/service/validation/json-validator.ts
+++ b/src/lib/src/service/validation/json-validator.ts
@@ -1,0 +1,209 @@
+import { JSONSchema } from './json-schema';
+
+/**
+ * @todo Delete console.log on prod environment ?
+ * @todo Add other JSON Schema validation features
+ */
+export class JSONValidator {
+
+  protected readonly simpleTypes = ['string', 'number', 'boolean', 'object'];
+
+  protected isObjectNotNull(value: any) {
+
+    return (value !== null) && (typeof value === 'object');
+
+  }
+
+  protected valueInvalid(error: string) {
+
+    console.log(error);
+
+    return false;
+
+  }
+
+  /**
+   * Validate a JSON data against a JSON Schema
+   * @param data JSON data to validate
+   * @param schema Subset of JSON Schema draft 6
+   * @returns If data is valid : true, if it is invalid : false, and throws if the schema is invalid
+   */
+  validate(data: any, schema: JSONSchema) {
+
+    if (!this.isObjectNotNull(schema)) {
+
+      throw new Error(`A schema must be an object (unlike spec, booleans are not supported to enforce strict types).`);
+
+    }
+
+    if ((!schema.hasOwnProperty('type') || schema.type === 'array' || schema.type === 'object')
+    && !schema.hasOwnProperty('properties') && !schema.hasOwnProperty('items')) {
+
+      throw new Error(`Each value must have a 'type' or 'properties' or 'items', to enforce strict types.`);
+
+    }
+
+    if (schema.hasOwnProperty('type') && !this.validateType(data, schema)) {
+      return false;
+    }
+
+    if (schema.hasOwnProperty('items') && !this.validateItems(data, schema)) {
+      return false;
+    }
+
+    if (schema.hasOwnProperty('properties')) {
+
+      if (schema.hasOwnProperty('required') && !this.validateRequired(data, schema)) {
+        return false;
+      }
+
+      if (!this.validateProperties(data, schema)) {
+        return false;
+      }
+
+    }
+
+    return true;
+
+  }
+
+  protected validateProperties(data: {}, schema: JSONSchema) {
+
+    if (!this.isObjectNotNull(data)) {
+
+      return this.valueInvalid(`A value with 'properties' must be an object.`);
+
+    }
+
+    if (!schema.properties || !this.isObjectNotNull(schema.properties)) {
+
+      throw new Error(`'properties' must be a schema object.`);
+
+    }
+
+    /**
+     * Check if the object doesn't have more properties than expected
+     * Equivalent of additionalProperties: false
+     */
+    if (Object.keys(schema.properties).length !== Object.keys(data).length) {
+
+      return this.valueInvalid(`Properties set as required should be present in 'properties' too (to enforce strict types).`);
+
+    }
+
+    /* Recursively validate all properties */
+    for (let property in schema.properties) {
+
+      if (schema.properties.hasOwnProperty(property) && data.hasOwnProperty(property)) {
+
+        if (!this.validate(data[property], schema.properties[property])) {
+
+          return false;
+
+        }
+
+      }
+
+    }
+
+    return true;
+
+  }
+
+  protected validateRequired(data: {}, schema: JSONSchema) {
+
+    if (!this.isObjectNotNull(data)) {
+
+      return this.valueInvalid(`A value with 'required' must be an object.`);
+
+    }
+
+    if (!Array.isArray(schema.required)) {
+
+      throw new Error(`'required' field must be an array. Note that since JSON Schema draft 6, booleans are not supported anymore.`);
+
+    }
+
+    for (let requiredProp of schema.required) {
+
+      if (typeof requiredProp !== 'string') {
+
+        throw new Error(`'required' array must contain strings only.`);
+
+      }
+
+      /* Checks if the property is present in the schema 'properties' */
+      if (!schema.properties || !schema.properties.hasOwnProperty(requiredProp)) {
+
+        throw new Error(`'required' properties must be described in 'properties' too.`);
+
+      }
+
+      /* Checks if the property is present in the data */
+      if (!data.hasOwnProperty(requiredProp)) {
+
+        return this.valueInvalid(`Required ${requiredProp} property is missing.`);
+
+      }
+
+    }
+
+    return true;
+
+  }
+
+  protected validateType(data: any, schema: JSONSchema) {
+
+    if (typeof schema.type !== 'string') {
+
+      throw new Error(`'type' must be a string (arrays of types are not supported yet).`);
+
+    }
+
+    if ((schema.type === 'null') && (data !== null)) {
+
+      return this.valueInvalid(`Value invalid, should be null`);
+
+    }
+
+    if ((this.simpleTypes.indexOf(schema.type) !== -1) && (typeof data !== schema.type)) {
+
+      return this.valueInvalid(`Value invalid, should be of type ${schema.type}`);
+
+    }
+
+    if ((schema.type === 'integer') && ((typeof data !== 'number') || !Number.isInteger(data))) {
+
+      return this.valueInvalid(`Value invalid, should be an integer`);
+
+    }
+
+    return true;
+
+  }
+
+  protected validateItems(data: any[], schema: JSONSchema) {
+
+    if (!schema.items || !this.isObjectNotNull(schema.items)) {
+
+      throw new Error(`'items' must be a schema object.`);
+
+    }
+
+    if (!Array.isArray(data)) {
+      return false;
+    }
+
+    for (let value of data) {
+
+      if (!this.validate(value, schema.items)) {
+        return false;
+      }
+
+    }
+
+    return true;
+
+  }
+
+}

--- a/src/lib/src/service/validation/json-validator.ts
+++ b/src/lib/src/service/validation/json-validator.ts
@@ -1,7 +1,6 @@
 import { JSONSchema, JSONSchemaType } from './json-schema';
 
 /**
- * @todo Delete console.log in prod environment ?
  * @todo Add other JSON Schema validation features
  */
 export class JSONValidator {
@@ -11,14 +10,6 @@ export class JSONValidator {
   protected isObjectNotNull(value: any) {
 
     return (value !== null) && (typeof value === 'object');
-
-  }
-
-  protected valueInvalid(error: string) {
-
-    console.log(error);
-
-    return false;
 
   }
 
@@ -71,7 +62,7 @@ export class JSONValidator {
 
     if (!this.isObjectNotNull(data)) {
 
-      return this.valueInvalid(`A value with 'properties' must be an object.`);
+      return false;
 
     }
 
@@ -87,7 +78,7 @@ export class JSONValidator {
      */
     if (Object.keys(schema.properties).length !== Object.keys(data).length) {
 
-      return this.valueInvalid(`Properties set as required should be present in 'properties' too (to enforce strict types).`);
+      return false;
 
     }
 
@@ -114,7 +105,7 @@ export class JSONValidator {
 
     if (!this.isObjectNotNull(data)) {
 
-      return this.valueInvalid(`A value with 'required' must be an object.`);
+      return false;
 
     }
 
@@ -142,7 +133,7 @@ export class JSONValidator {
       /* Checks if the property is present in the data */
       if (!data.hasOwnProperty(requiredProp)) {
 
-        return this.valueInvalid(`Required ${requiredProp} property is missing.`);
+        return false;
 
       }
 
@@ -168,19 +159,19 @@ export class JSONValidator {
 
     if ((schema.type === 'null') && (data !== null)) {
 
-      return this.valueInvalid(`Value invalid, should be null`);
+      return false;
 
     }
 
     if ((this.simpleTypes.indexOf(schema.type) !== -1) && (typeof data !== schema.type)) {
 
-      return this.valueInvalid(`Value invalid, should be of type ${schema.type}`);
+      return false;
 
     }
 
     if ((schema.type === 'integer') && ((typeof data !== 'number') || !Number.isInteger(data))) {
 
-      return this.valueInvalid(`Value invalid, should be an integer`);
+      return false;
 
     }
 
@@ -209,7 +200,7 @@ export class JSONValidator {
 
     if (!Array.isArray(data)) {
 
-      return this.valueInvalid(`One of the value should be an array.`);
+      return false;
 
     }
 
@@ -243,7 +234,7 @@ export class JSONValidator {
 
     if (data.length !== items.length) {
 
-      return this.valueInvalid(`An array does not match the number of items.`);
+      return false;
 
     }
 


### PR DESCRIPTION
As mentioned in README : 

> it's client-side storage : always check the data, as it could have been forged or deleted.

So I propose to introduce some validation based on [JSON Schema](http://json-schema.org/).

To test it : 

`npm install angular-async-local-storage@beta`

The API works like this : 

```typescript
import { JSONSchema } from 'angular-async-local-storage';

const schema: JSONSchema = {
  properties: {
    expected: {
      type: 'string'
    }
  },
  required: ['expected']
};

this.localStorage.getItem<{ expected: string }>(index, { schema }).subscribe((data) => {
  /* if data is valid or null */
}, (error) => {
  /* if data or schema are invalid */
});
```

**Do NOT use in production.** The beta is working and backward-compatible, but the API may change significantly. Angular 5 is required.

My main concern is how to manage invalid data : classic behavior would be to throw an error, but as `localStorage` was never throwing before (just returning `null`), it would force people to handle the error callback.

~~For now, invalid data is just changed to `null`, but discussion is opened. I would like other opinions before going final with this feature.~~ (see next comment)

Note that not all of JSON Schema features are supported yet, just the main features to type (just follow the `JSONSchema` interface provided).