### PR TITLE
feat: simpler validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,56 @@ This lib is fully documented and so you'll find detailed [migration guides](./MI
 
 ## 7.5.0 (2019-01-18)
 
-### Feature
+### Features
 
 - Added predefined constants for basic JSON schemas to simplify validation:
   - `SCHEMA_BOOLEAN` (shortcut for: `{ type: 'boolean' }`)
   - `SCHEMA_INTEGER` (shortcut for: `{ type: 'integer' }`)
   - `SCHEMA_NUMBER` (shortcut for: `{ type: 'number' }`)
   - `SCHEMA_STRING` (shortcut for: `{ type: 'string' }`)
+  - `SCHEMA_ARRAY_OF_BOOLEANS` (shortcut for: `{ items: { type: 'boolean' } }`)
+  - `SCHEMA_ARRAY_OF_INTEGER` (shortcut for: `{ items: { type: 'integer' } }`)
+  - `SCHEMA_ARRAY_OF_NUMBER` (shortcut for: `{ items: { type: 'number' } }`)
+  - `SCHEMA_ARRAY_OF_STRINGS` (shortcut for: `{ items: { type: 'string' } }`)
 
-See the [new validation guide](./docs/VALIDATION.md).
+This is especially useful for advanced types (arrays, objects, nested types),
+to avoid TypeScript limitations.
+
+- For the same types as above, the result type is now automatically infered,
+meaning you don't need to cast anymore!
+
+Before v7.5:
+```typescript
+this.localStorage.getItem('test', { schema: { type: 'string' } })
+.subscribe((result) => {
+  result; // type: any :(
+});
+
+this.localStorage.getItem<string>('test', { schema: { type: 'string' } })
+.subscribe((result) => {
+  result; // type: string :)
+});
+```
+
+From v7.5:
+```typescript
+import { SCHEMA_STRING } from '@ngx-pwa/local-storage';
+
+this.localStorage.getItem('test', { schema: SCHEMA_STRING })
+.subscribe((result) => {
+  result; // type: string :D
+});
+```
+
+- Added better interfaces for some JSON schemas:
+  - `JSONSchemaArrayOf<T>`
+  - `JSONSchemaConstOf<T>`
+  - `JSONSchemaEnumOf<T>`
+
+**See the [new validation guide](./docs/VALIDATION.md).**
+
+This is only a feature release, so don't worry: nothing changes in existing code.
+It's just new tools to simplify validation and thus ease migration to v7.
 
 ## 7.4.0 (2019-01-12)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 This lib is fully documented and so you'll find detailed [migration guides](./MIGRATION.md).
 
+## 7.5.0 (2019-01-18)
+
+### Feature
+
+- Added predefined constants for basic JSON schemas to simplify validation:
+  - `SCHEMA_BOOLEAN` (shortcut for: `{ type: 'boolean' }`)
+  - `SCHEMA_INTEGER` (shortcut for: `{ type: 'integer' }`)
+  - `SCHEMA_NUMBER` (shortcut for: `{ type: 'number' }`)
+  - `SCHEMA_STRING` (shortcut for: `{ type: 'string' }`)
+
+See the [new validation guide](./docs/VALIDATION.md).
+
 ## 7.4.0 (2019-01-12)
 
 ### Feature

--- a/README.md
+++ b/README.md
@@ -111,8 +111,6 @@ this.localStorage.getItem<User>('user').subscribe((user) => {
 });
 ```
 
-As any data can be stored, you can type your data.
-
 Not finding an item is not an error, it succeeds but returns `null`.
 
 ```typescript
@@ -133,7 +131,7 @@ Starting with *version 5*, you can use a [JSON Schema](http://json-schema.org/) 
 A [migration guide](./docs/MIGRATION_TO_V7.md) is available.
 
 ```typescript
-this.localStorage.getItem<string>('test', { schema: { type: 'string' } })
+this.localStorage.getItem('test', { schema: { type: 'string' } })
 .subscribe((user) => {
   // Called if data is valid or null
 }, (error) => {

--- a/docs/MIGRATION_TO_V7.md
+++ b/docs/MIGRATION_TO_V7.md
@@ -69,13 +69,10 @@ this.localStorage.getItem<string>('test').subscribe((result) => {
 });
 ```
 
-It's only a convenience allowed by the library. It's useful when you're already validating the data with a JSON schema,
-to cast the data type.
-
-But **when you were not validating the data, it was really bad**.
+`getItem<string>` **doesn't perform any real validation**.
 Casting like this only means: "TypeScript, trust me, I'm telling you it will be a string".
 But TypeScript won't do any real validation as it can't:
-**TypeScript can only manage checks at compilation time, while client-side storage checks can only happen at runtime**.
+**TypeScript can only manage checks at *compilation* time, while client-side storage checks can only happen at *runtime***.
 
 So you ended up with a `string` type while the real data may not be a `string` at all, leading to security issues and errors.
 
@@ -89,7 +86,9 @@ The simpler and better way to validate your data is to search `getItem` in your 
 and **use the JSON schema option proposed by the lib**. For example:
 
 ```typescript
-this.localStorage.getItem<string>('test', { schema: { type: 'string' } })
+import { SCHEMA_STRING } from '@ngx-pwa/local-storage';
+
+this.localStorage.getItem('test', { schema: SCHEMA_STRING })
 .subscribe((result) => {
   result; // type: string
   result.substr(0, 2); // OK
@@ -97,6 +96,10 @@ this.localStorage.getItem<string>('test', { schema: { type: 'string' } })
 ```
 
 **A [full validation guide](./VALIDATION.md) is available with all the options.**
+
+Note the above example only works with version >= 7.5, which has done a lot of things to simplify validation:
+- predefined constants (like `SCHEMA_STRING`) are available for common structures,
+- casting (`.getItem<string>`) is no longer required for most types, as it's now automatically infered.
 
 ### Solution 2: custom validation (painful)
 

--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -108,6 +108,7 @@ interface User {
 }
 
 const schema: JSONSchemaObject = {
+  type: 'object',
   properties: {
     firstName: SCHEMA_STRING,
     lastName: SCHEMA_STRING,
@@ -216,6 +217,7 @@ For example:
 import { JSONSchemaArrayOf, JSONSchemaString, SCHEMA_STRING } from '@ngx-pwa/local-storage';
 
 const schema: JSONSchemaArrayOf<JSONSchemaString> = {
+  type: 'array',
   items: SCHEMA_STRING,
   maxItems: 5
 };
@@ -239,7 +241,9 @@ interface User {
 }
 
 const schema: JSONSchemaArray = {
+  type: 'array',
   items: {
+    type: 'object',
     properties: {
       firstName: {
         type: 'string',

--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -26,119 +26,77 @@ It can have many uses (it's why you have autocompletion in some JSON files in Vi
 The JSON schema standard has its own [documentation](https://json-schema.org/),
 and you can also follow the `JSONSchema` interfaces exported by the lib. But as a convenience, we'll show here how to validate the common scenarios.
 
-## How to validate?
+## How to validate simple data
 
-### Validating a boolean
+As a general recommendation, we recommend to keep your data structures as simple as possible,
+as you'll see the more complex it is, the more complex is validation too.
+
+### Shortcut for a boolean
 
 ```typescript
 import { SCHEMA_BOOLEAN } from '@ngx-pwa/local-storage';
 
-this.localStorage.getItem<boolean>('test', { schema: SCHEMA_BOOLEAN })
+this.localStorage.getItem('test', { schema: SCHEMA_BOOLEAN })
 ```
 
-Which is a shortcut for:
-```typescript
-import { JSONSchemaBoolean } from '@ngx-pwa/local-storage';
+### Shortcut for an integer
 
-const schema: JSONSchemaBoolean = { type: 'boolean' };
-
-this.localStorage.getItem<boolean>('test', { schema })
-```
-
-### Validating a number
-
-For a number:
-```typescript
-import { SCHEMA_NUMBER } from '@ngx-pwa/local-storage';
-
-this.localStorage.getItem<number>('test', { schema: SCHEMA_NUMBER })
-```
-
-For an integer only:
 ```typescript
 import { SCHEMA_INTEGER } from '@ngx-pwa/local-storage';
 
-this.localStorage.getItem<number>('test', { schema: SCHEMA_INTEGER })
+this.localStorage.getItem('test', { schema: SCHEMA_INTEGER })
 ```
 
-For numbers and integers, you can also add the following optional validations:
-- `multipleOf`
-- `maximum`
-- `exclusiveMaximum`
-- `minimum`
-- `exclusiveMinimum`
+### Shortcut for a number
+
+```typescript
+import { SCHEMA_NUMBER } from '@ngx-pwa/local-storage';
+
+this.localStorage.getItem('test', { schema: SCHEMA_NUMBER })
+```
+
+### Shortcut for a string
+
+```typescript
+import { SCHEMA_STRING } from '@ngx-pwa/local-storage';
+
+this.localStorage.getItem('test', { schema: SCHEMA_STRING })
+```
+
+### Shortcuts for arrays
+
+```typescript
+import { SCHEMA_ARRAY_OF_BOOLEANS } from '@ngx-pwa/local-storage';
+
+this.localStorage.getItem('test', { schema: SCHEMA_ARRAY_OF_BOOLEANS })
+```
+
+```typescript
+import { SCHEMA_ARRAY_OF_INTEGERS } from '@ngx-pwa/local-storage';
+
+this.localStorage.getItem('test', { schema: SCHEMA_ARRAY_OF_INTEGERS })
+```
+
+```typescript
+import { SCHEMA_ARRAY_OF_NUMBERS } from '@ngx-pwa/local-storage';
+
+this.localStorage.getItem('test', { schema: SCHEMA_ARRAY_OF_NUMBERS })
+```
+
+```typescript
+import { SCHEMA_ARRAY_OF_STRINGS } from '@ngx-pwa/local-storage';
+
+this.localStorage.getItem('test', { schema: SCHEMA_ARRAY_OF_STRINGS })
+```
+
+## How to validate objects
+
+As the properties of an object are dynamic (it can be anything),
+validating an object requires more work:
+- a full JSON schema must be used,
+- a cast must be added (otherwise the result will be of type `any`).
 
 For example:
-```typescript
-import { JSONSchemaNumeric } from '@ngx-pwa/local-storage';
-
-const schema: JSONSchemaNumeric = {
-  type: 'number',
-  maximum: 5
-};
-
-this.localStorage.getItem<number>('test', { schema })
-```
-
-### Validating a string
-
-```typescript
-import { JSONSchemaString } from '@ngx-pwa/local-storage';
-
-const schema: JSONSchemaString = { type: 'string' };
-
-this.localStorage.getItem<string>('test', { schema })
-```
-
-For strings, you can also add the following optional validations:
-- `maxLength`
-- `minLength`
-- `pattern`
-
-For example:
-```typescript
-import { JSONSchemaString } from '@ngx-pwa/local-storage';
-
-const schema: JSONSchemaString = {
-  type: 'string',
-  maxLength: 10
-};
-
-this.localStorage.getItem<string>('test', { schema })
-```
-
-### Validating an array
-
-```typescript
-import { JSONSchemaArray, SCHEMA_STRING } from '@ngx-pwa/local-storage';
-
-const schema: JSONSchemaArray = { items: SCHEMA_STRING };
-
-this.localStorage.getItem<string[]>('test', { schema })
-```
-
-What's expected in `items` is another JSON schema,
-so you can also add the other optional validations related to the chosen type.
-
-For arrays, you can also add the following optional validations:
-- `maxItems`
-- `minItems`
-- `uniqueItems`
-
-For example:
-```typescript
-import { JSONSchemaArray, SCHEMA_STRING } from '@ngx-pwa/local-storage';
-
-const schema: JSONSchemaArray = {
-  items: SCHEMA_STRING,
-  maxItems: 5
-};
-
-this.localStorage.getItem<string[]>('test', { schema })
-```
-
-### Validating an object
-
 ```typescript
 import { JSONSchemaObject, SCHEMA_NUMBER, SCHEMA_STRING } from '@ngx-pwa/local-storage';
 
@@ -163,27 +121,112 @@ this.localStorage.getItem<User>('test', { schema })
 What's expected for each property is another JSON schema,
 so you can also add the other optional validations related to the chosen type.
 
-### Validating fixed values
+### Why a schema *and* a cast?
 
-If it can only be a fixed value:
+You may ask why we have to define a TypeScript cast with `getItem<User>()` *and* a JSON schema with `{ schema }`.
+
+It's because they happen at different steps:
+- a cast (`getItem<User>()`) just says "TypeScript, trust me, I'm telling you it will be a `User`", but it only happens at *compilation* time (it won't be checked at runtime)
+- the JSON schema (`{ schema }`) will be used at *runtime* when getting data in local storage for real.
+
+For previous structures, which are static, we can infer the final result type based on the JSON schema.
+But as in an object properties are dynamic (we can't now in advance what properties names and types there will be),
+automatic inference is not possible here.
+
+Be aware **you are responsible the casted type (`User`) describes the same structure as the JSON schema**.
+The lib can't check that.
+
+## How to validate fixed values
+
+### Const
+
 ```typescript
-import { JSONSchemaConst } from '@ngx-pwa/local-storage';
+import { JSONSchemaConstOf } from '@ngx-pwa/local-storage';
 
-const schema: JSONSchemaConst = { const: 'some value' };
+const schema: JSONSchemaConstOf<string> = { const: 'some value' };
 
-this.localStorage.getItem<string>('test', { schema })
+this.localStorage.getItem('test', { schema })
 ```
 
-If it can only be a fixed value among a list:
+Parameter type for `JSONSchemaConstOf` can be `string` or `number`.
+
+### Enum
+
 ```typescript
-import { JSONSchemaEnum } from '@ngx-pwa/local-storage';
+import { JSONSchemaEnumOf } from '@ngx-pwa/local-storage';
 
-const schema: JSONSchemaEnum = { enum: ['value 1', 'value 2'] };
+const schema: JSONSchemaEnumOf<string> = { enum: ['value 1', 'value 2'] };
 
-this.localStorage.getItem<string>('test', { schema })
+this.localStorage.getItem('test', { schema })
 ```
 
-### Validating nested types
+Parameter type for `JSONSchemaEnumOf` can be `string` or `number` or `boolean`.
+
+## Additional validation
+
+Some types have additional validation options. A full JSON schema must be used for those.
+
+### Options for integers and numbers
+
+- `multipleOf`
+- `maximum`
+- `exclusiveMaximum`
+- `minimum`
+- `exclusiveMinimum`
+
+For example:
+
+```typescript
+import { JSONSchemaNumeric } from '@ngx-pwa/local-storage';
+
+const schema: JSONSchemaNumeric = {
+  type: 'number',
+  maximum: 5
+};
+
+this.localStorage.getItem('test', { schema })
+```
+
+### Options for strings
+
+- `maxLength`
+- `minLength`
+- `pattern`
+
+For example:
+```typescript
+import { JSONSchemaString } from '@ngx-pwa/local-storage';
+
+const schema: JSONSchemaString = {
+  type: 'string',
+  maxLength: 10
+};
+
+this.localStorage.getItem('test', { schema })
+```
+
+### Options for arrays
+
+- `maxItems`
+- `minItems`
+- `uniqueItems`
+
+For example:
+```typescript
+import { JSONSchemaArrayOf, JSONSchemaString, SCHEMA_STRING } from '@ngx-pwa/local-storage';
+
+const schema: JSONSchemaArrayOf<JSONSchemaString> = {
+  items: SCHEMA_STRING,
+  maxItems: 5
+};
+
+this.localStorage.getItem('test', { schema })
+```
+
+What's expected in `items` is another JSON schema,
+so you can also add the other optional validations related to the chosen type.
+
+## How to validate nested types
 
 Due to a limitation of TypeScript, when nesting array, objects or advanced types,
 you'll need to cast subschemas:
@@ -212,14 +255,12 @@ const schema: JSONSchemaArray = {
 this.localStorage.getItem<User[]>('test', { schema })
 ```
 
-As a general recommendation, keep your data structures as simple as possible.
-
 ## Errors vs. `null`
 
 If validation fails, it'll go in the error callback:
 
 ```typescript
-this.localStorage.getItem<string>('existing', { schema: SCHEMA_STRING })
+this.localStorage.getItem('existing', { schema: SCHEMA_STRING })
 .subscribe((result) => {
   // Called if data is valid or null
 }, (error) => {
@@ -230,7 +271,7 @@ this.localStorage.getItem<string>('existing', { schema: SCHEMA_STRING })
 But as usual (like when you do a database request), not finding an item is not an error. It succeeds but returns `null`.
 
 ```typescript
-this.localStorage.getItem<string>('notExisting', { schema: SCHEMA_STRING })
+this.localStorage.getItem('notExisting', { schema: SCHEMA_STRING })
 .subscribe((result) => {
   result; // null
 }, (error) => {
@@ -263,21 +304,6 @@ are *not* available in this lib:
 - `anyOf`
 - `oneOf`
 - array for `type`
-
-## Why a schema AND a cast?
-
-You may ask why we have to define a TypeScript cast with `getItem<string>()` AND a JSON schema with `{ schema: SCHEMA_STRING }`.
-
-It's because a cast only means: "TypeScript, trust me, I'm telling you it will be a string".
-But TypeScript won't do any real validation as it can't:
-**TypeScript can only manage checks at compilation time, while client-side storage checks can only happen at runtime**.
-So the JSON schema is required for real validation.
-
-And in the opposite way, the JSON schema doesn't tell TypeScript what will be the type of the data.
-So the cast is a convenience so you don't end up with `any` while you already checked the data.
-
-It means **you are responsible the casted type describes the same structure as the JSON schema**.
-The lib can't check that.
 
 ## Why specific JSONSchema interfaces?
 

--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -24,7 +24,8 @@ It can have many uses (it's why you have autocompletion in some JSON files in Vi
 **In this lib, JSON schemas are used to validate the data retrieved from local storage.**
 
 The JSON schema standard has its own [documentation](https://json-schema.org/),
-and you can also follow the `JSONSchema` interfaces exported by the lib. But as a convenience, we'll show here how to validate the common scenarios.
+and you can also follow the `JSONSchema` interfaces exported by the lib.
+But we recommend to following examples.
 
 ## How to validate simple data
 
@@ -118,8 +119,7 @@ const schema: JSONSchemaObject = {
 this.localStorage.getItem<User>('test', { schema })
 ```
 
-What's expected for each property is another JSON schema,
-so you can also add the other optional validations related to the chosen type.
+What's expected for each property is another JSON schema.
 
 ### Why a schema *and* a cast?
 
@@ -223,8 +223,7 @@ const schema: JSONSchemaArrayOf<JSONSchemaString> = {
 this.localStorage.getItem('test', { schema })
 ```
 
-What's expected in `items` is another JSON schema,
-so you can also add the other optional validations related to the chosen type.
+What's expected in `items` is another JSON schema.
 
 ## How to validate nested types
 
@@ -305,16 +304,17 @@ are *not* available in this lib:
 - `oneOf`
 - array for `type`
 
-## Why specific JSONSchema interfaces?
+## Other notes
+
+### Why specific JSONSchema interfaces?
 
 Unfortunately, the JSON schema standard is structured in such a way it's currently impossible to do an equivalent TypeScript interface,
 which would be generic for all types, but only allowing you the optional validations relative to the type you choose
 (for example, `maxLength` should only be allowed when `type` is set to `'string'`).
 
 Thus casting with a more specific interface (like `JSONSchemaString`) allows TypeScript to check your JSON Schema is really valid.
-But it's not mandatory.
 
-## ES6 shortcut
+### ES6 shortcut
 
 In EcmaScript >= 6, this:
 

--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -183,12 +183,13 @@ const schema: JSONSchemaEnum = { enum: ['value 1', 'value 2'] };
 this.localStorage.getItem<string>('test', { schema })
 ```
 
-### Validating nested array/objects types
+### Validating nested types
 
-When nesting array and/or objects, you'll need to cast subschemas:
+Due to a limitation of TypeScript, when nesting array, objects or advanced types,
+you'll need to cast subschemas:
 
 ```typescript
-import { JSONSchemaArray, JSONSchemaObject, SCHEMA_STRING } from '@ngx-pwa/local-storage';
+import { JSONSchemaArray, JSONSchemaObject, JSONSchemaString, SCHEMA_STRING } from '@ngx-pwa/local-storage';
 
 interface User {
   firstName: string;
@@ -198,7 +199,10 @@ interface User {
 const schema: JSONSchemaArray = {
   items: {
     properties: {
-      firstName: SCHEMA_STRING,
+      firstName: {
+        type: 'string',
+        maxLength: 10
+      } as JSONSchemaString,
       lastName: SCHEMA_STRING
     },
     required: ['firstName', 'lastName']

--- a/docs/VALIDATION_BEFORE_V7.5.md
+++ b/docs/VALIDATION_BEFORE_V7.5.md
@@ -1,5 +1,10 @@
 # Validation guide
 
+## Old guide
+
+This is the validation guide for versions < 7.5.
+[The up to date guide is available here](./VALIDATION.md).
+
 ## Why validation?
 
 Any client-side storage (cookies, `localStorage`, `indexedDb`...) is not secure by nature,

--- a/projects/ngx-pwa/local-storage/package.json
+++ b/projects/ngx-pwa/local-storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngx-pwa/local-storage",
-  "version": "7.4.0",
+  "version": "7.5.0",
   "description": "Efficient local storage module for Angular apps and PWA: simple API based on native localStorage API, but internally stored via the asynchronous IndexedDB API for performance, and wrapped in RxJS observables to be homogeneous with other Angular modules.",
   "author": "Cyrille Tuzi",
   "license": "MIT",

--- a/projects/ngx-pwa/local-storage/src/lib/get-item-overloads.spec.ts
+++ b/projects/ngx-pwa/local-storage/src/lib/get-item-overloads.spec.ts
@@ -1,7 +1,7 @@
 import { LocalStorage } from './lib.service';
 import { IndexedDBDatabase } from './databases/indexeddb-database';
 import { JSONValidator } from './validation/json-validator';
-import { SCHEMA_STRING, SCHEMA_ARRAY_OF_BOOLEANS } from './validation/constants';
+import { SCHEMA_STRING, SCHEMA_ARRAY_OF_NUMBERS, SCHEMA_ARRAY_OF_BOOLEANS, SCHEMA_ARRAY_OF_STRINGS } from './validation/constants';
 import { JSONSchemaString, JSONSchema, JSONSchemaArrayOf } from './validation/json-schema';
 
 describe('getItem() overload signature', () => {
@@ -230,7 +230,7 @@ describe('getItem() overload signature', () => {
 
   it('should compile for array of strings', (done: DoneFn) => {
 
-    localStorageService.getItem('test', { schema: { items: { type: 'string' } } }).subscribe((_) => {
+    localStorageService.getItem('test', { schema: SCHEMA_ARRAY_OF_STRINGS }).subscribe((_) => {
 
       expect().nothing();
 
@@ -242,7 +242,7 @@ describe('getItem() overload signature', () => {
 
   it('should compile for array of numbers', (done: DoneFn) => {
 
-    localStorageService.getItem('test', { schema: { items: { type: 'number' } } }).subscribe((_) => {
+    localStorageService.getItem('test', { schema: SCHEMA_ARRAY_OF_NUMBERS }).subscribe((_) => {
 
       expect().nothing();
 
@@ -254,7 +254,7 @@ describe('getItem() overload signature', () => {
 
   it('should compile for array of booleans', (done: DoneFn) => {
 
-    localStorageService.getItem('test', { schema: { items: { type: 'boolean' } } }).subscribe((_) => {
+    localStorageService.getItem('test', { schema: SCHEMA_ARRAY_OF_BOOLEANS }).subscribe((_) => {
 
       expect().nothing();
 
@@ -267,6 +267,7 @@ describe('getItem() overload signature', () => {
   it('should compile for array with extra options', (done: DoneFn) => {
 
     const schema: JSONSchemaArrayOf<JSONSchemaString> = {
+      type: 'array',
       items: { type: 'string' },
       maxItems: 5
     };

--- a/projects/ngx-pwa/local-storage/src/lib/get-item-overloads.spec.ts
+++ b/projects/ngx-pwa/local-storage/src/lib/get-item-overloads.spec.ts
@@ -8,9 +8,15 @@ describe('getItem() overload signature', () => {
 
   let localStorageService: LocalStorage;
 
-  beforeEach(() => {
+  beforeEach((done: DoneFn) => {
 
     localStorageService = new LocalStorage(new IndexedDBDatabase(), new JSONValidator());
+
+    localStorageService.clear().subscribe(() => {
+
+      done();
+
+    });
 
   });
 

--- a/projects/ngx-pwa/local-storage/src/lib/get-item-overloads.spec.ts
+++ b/projects/ngx-pwa/local-storage/src/lib/get-item-overloads.spec.ts
@@ -1,0 +1,346 @@
+import { LocalStorage } from './lib.service';
+import { IndexedDBDatabase } from './databases/indexeddb-database';
+import { JSONValidator } from './validation/json-validator';
+import { SCHEMA_STRING, SCHEMA_ARRAY_OF_BOOLEANS } from './validation/constants';
+import { JSONSchemaString, JSONSchema, JSONSchemaArrayOf } from './validation/json-schema';
+
+describe('getItem() overload signature', () => {
+
+  let localStorageService: LocalStorage;
+
+  beforeEach(() => {
+
+    localStorageService = new LocalStorage(new IndexedDBDatabase(), new JSONValidator());
+
+  });
+
+  it('should compile with no schema and without cast', (done: DoneFn) => {
+
+    localStorageService.getItem('test').subscribe((_) => {
+
+      expect().nothing();
+
+      done();
+
+    });
+
+  });
+
+  it('should compile with no schema and with cast', (done: DoneFn) => {
+
+    localStorageService.getItem<string>('test').subscribe((_) => {
+
+      expect().nothing();
+
+      done();
+
+    });
+
+  });
+
+  it('should compile with literal basic schema and without type param', (done: DoneFn) => {
+
+    localStorageService.getItem('test', { schema: { type: 'string' } }).subscribe((_) => {
+
+      expect().nothing();
+
+      done();
+
+    });
+
+  });
+
+  it('should compile with literal basic schema and with type param', (done: DoneFn) => {
+
+    localStorageService.getItem<string>('test', { schema: { type: 'string' } }).subscribe((_) => {
+
+      expect().nothing();
+
+      done();
+
+    });
+
+  });
+
+  it('should compile with literal basic schema and extra options', (done: DoneFn) => {
+
+    localStorageService.getItem<string>('test', { schema: { type: 'string', maxLength: 10 } }).subscribe((_) => {
+
+      expect().nothing();
+
+      done();
+
+    });
+
+  });
+
+  it('should compile with predefined basic schema and without type param', (done: DoneFn) => {
+
+    localStorageService.getItem('test', { schema: SCHEMA_STRING }).subscribe((_) => {
+
+      expect().nothing();
+
+      done();
+
+    });
+
+  });
+
+  it('should compile with predefined basic schema and with type param', (done: DoneFn) => {
+
+    localStorageService.getItem<string>('test', { schema: SCHEMA_STRING }).subscribe((_) => {
+
+      expect().nothing();
+
+      done();
+
+    });
+
+  });
+
+  it('should compile with prepared basic schema and with specific interface', (done: DoneFn) => {
+
+    const schema: JSONSchemaString = { type: 'string' };
+
+    localStorageService.getItem('test', { schema }).subscribe((_) => {
+
+      expect().nothing();
+
+      done();
+
+    });
+
+  });
+
+  it('should compile with prepared basic schema and with generic interface', (done: DoneFn) => {
+
+    const schema: JSONSchema = { type: 'string' };
+
+    localStorageService.getItem('test', { schema }).subscribe((_) => {
+
+      expect().nothing();
+
+      done();
+
+    });
+
+  });
+
+  it('should compile for string type', (done: DoneFn) => {
+
+    localStorageService.getItem('test', { schema: { type: 'string' } }).subscribe((_) => {
+
+      expect().nothing();
+
+      done();
+
+    });
+
+  });
+
+  it('should compile for number type', (done: DoneFn) => {
+
+    localStorageService.getItem('test', { schema: { type: 'number' } }).subscribe((_) => {
+
+      expect().nothing();
+
+      done();
+
+    });
+
+  });
+
+  it('should compile for boolean type', (done: DoneFn) => {
+
+    localStorageService.getItem('test', { schema: { type: 'boolean' } }).subscribe((_) => {
+
+      expect().nothing();
+
+      done();
+
+    });
+
+  });
+
+  it('should compile for const string type', (done: DoneFn) => {
+
+    localStorageService.getItem('test', { schema: { const: 'test' } }).subscribe((_) => {
+
+      expect().nothing();
+
+      done();
+
+    });
+
+  });
+
+  it('should compile for const number type', (done: DoneFn) => {
+
+    localStorageService.getItem('test', { schema: { const: 5 } }).subscribe((_) => {
+
+      expect().nothing();
+
+      done();
+
+    });
+
+  });
+
+  it('should compile for const boolean type', (done: DoneFn) => {
+
+    localStorageService.getItem('test', { schema: { const: false } }).subscribe((_) => {
+
+      expect().nothing();
+
+      done();
+
+    });
+
+  });
+
+  it('should compile for enum string type', (done: DoneFn) => {
+
+    localStorageService.getItem('test', { schema: { enum: ['test', 'test 2'] } }).subscribe((_) => {
+
+      expect().nothing();
+
+      done();
+
+    });
+
+  });
+
+  it('should compile for enum number type', (done: DoneFn) => {
+
+    localStorageService.getItem('test', { schema: { enum: [1, 2] } }).subscribe((_) => {
+
+      expect().nothing();
+
+      done();
+
+    });
+
+  });
+
+  it('should compile for array of strings', (done: DoneFn) => {
+
+    localStorageService.getItem('test', { schema: { items: { type: 'string' } } }).subscribe((_) => {
+
+      expect().nothing();
+
+      done();
+
+    });
+
+  });
+
+  it('should compile for array of numbers', (done: DoneFn) => {
+
+    localStorageService.getItem('test', { schema: { items: { type: 'number' } } }).subscribe((_) => {
+
+      expect().nothing();
+
+      done();
+
+    });
+
+  });
+
+  it('should compile for array of booleans', (done: DoneFn) => {
+
+    localStorageService.getItem('test', { schema: { items: { type: 'boolean' } } }).subscribe((_) => {
+
+      expect().nothing();
+
+      done();
+
+    });
+
+  });
+
+  it('should compile for array with extra options', (done: DoneFn) => {
+
+    const schema: JSONSchemaArrayOf<JSONSchemaString> = {
+      items: { type: 'string' },
+      maxItems: 5
+    };
+
+    localStorageService.getItem('test', { schema }).subscribe((_) => {
+
+      expect().nothing();
+
+      done();
+
+    });
+
+  });
+
+  it('should compile with predefined arrays', (done: DoneFn) => {
+
+    localStorageService.getItem('test', { schema: SCHEMA_ARRAY_OF_BOOLEANS }).subscribe((_) => {
+
+      expect().nothing();
+
+      done();
+
+    });
+
+  });
+
+  it('should compile for array of objects', (done: DoneFn) => {
+
+    interface Test {
+      test: string;
+    }
+
+    localStorageService.getItem<Test[]>('test', { schema: { items: {
+      properties: {
+        test: { type: 'string' } as JSONSchemaString
+      }
+    } } }).subscribe((_) => {
+
+      expect().nothing();
+
+      done();
+
+    });
+
+  });
+
+  it('should compile for objects without param type', (done: DoneFn) => {
+
+    localStorageService.getItem('test', { schema: {
+      properties: {
+        test: SCHEMA_STRING
+      }
+    } }).subscribe((_) => {
+
+      expect().nothing();
+
+      done();
+
+    });
+
+  });
+
+  it('should compile for objects with param type', (done: DoneFn) => {
+
+    interface Test {
+      test: string;
+    }
+
+    localStorageService.getItem<Test>('test', { schema: {
+      properties: {
+        test: SCHEMA_STRING
+      }
+    } }).subscribe((_) => {
+
+      expect().nothing();
+
+      done();
+
+    });
+
+  });
+
+});

--- a/projects/ngx-pwa/local-storage/src/lib/lib.service.spec.ts
+++ b/projects/ngx-pwa/local-storage/src/lib/lib.service.spec.ts
@@ -6,8 +6,9 @@ import { LocalStorage } from './lib.service';
 import { IndexedDBDatabase } from './databases/indexeddb-database';
 import { LocalStorageDatabase } from './databases/localstorage-database';
 import { MockLocalDatabase } from './databases/mock-local-database';
-import { JSONSchema, JSONSchemaString } from './validation/json-schema';
+import { JSONSchema } from './validation/json-schema';
 import { JSONValidator } from './validation/json-validator';
+import { SCHEMA_STRING, SCHEMA_NUMBER, SCHEMA_BOOLEAN } from './validation/constants';
 
 function testGetItem<T>(type: 'primitive' | 'object', localStorageService: LocalStorage, value: T, done: DoneFn) {
 
@@ -321,12 +322,9 @@ function tests(localStorageService: LocalStorage) {
     const value = {
       unexpected: 'value'
     };
-    // TODO: delete cast when TS 3.2 issue is fixed
     const schema: JSONSchema = {
       properties: {
-        expected: {
-          type: 'string'
-        } as JSONSchemaString
+        expected: SCHEMA_STRING
       },
       required: ['expected']
     };
@@ -357,12 +355,9 @@ function tests(localStorageService: LocalStorage) {
     const value = {
       expected: 'value'
     };
-    // TODO: delete cast when TS 3.2 issue is fixed
     const schema: JSONSchema = {
       properties: {
-        expected: {
-          type: 'string'
-        } as JSONSchemaString
+        expected: SCHEMA_STRING
       },
       required: ['expected']
     };
@@ -389,12 +384,9 @@ function tests(localStorageService: LocalStorage) {
 
   it('should return the data if the data is null (no validation)', (done: DoneFn) => {
 
-    // TODO: delete cast when TS 3.2 issue is fixed
     const schema: JSONSchema = {
       properties: {
-        expected: {
-          type: 'string'
-        } as JSONSchemaString
+        expected: SCHEMA_STRING
       },
       required: ['expected']
     };
@@ -949,15 +941,15 @@ describe('LocalStorage with IndexedDB', () => {
   }
 
   const getTestValues: [any, JSONSchema][] = [
-    ['hello', { type: 'string' }],
-    ['', { type: 'string' }],
-    [0, { type: 'number' }],
-    [1, { type: 'number' }],
-    [true, { type: 'boolean' }],
-    [false, { type: 'boolean' }],
+    ['hello', SCHEMA_STRING],
+    ['', SCHEMA_STRING],
+    [0, SCHEMA_NUMBER],
+    [1, SCHEMA_NUMBER],
+    [true, SCHEMA_BOOLEAN],
+    [false, SCHEMA_BOOLEAN],
     // TODO: delete cast when TS 3.2 issue is fixed
-    [[1, 2, 3], { items: { type: 'number' } } as JSONSchema],
-    [{ test: 'value' }, { properties: { test: { type: 'string' } } } as JSONSchema],
+    [[1, 2, 3], { items: SCHEMA_NUMBER }],
+    [{ test: 'value' }, { properties: { test: SCHEMA_STRING } }],
     [null, { type: 'null' }],
     [undefined, { type: 'null' }],
   ];

--- a/projects/ngx-pwa/local-storage/src/lib/lib.service.ts
+++ b/projects/ngx-pwa/local-storage/src/lib/lib.service.ts
@@ -10,6 +10,8 @@ import {
 import { JSONValidator } from './validation/json-validator';
 
 export interface LSGetItemOptions {
+  /** JSON schema which will be used to validate the data
+   * Predefined constants (`SCHEMA_`) are exported by the lib to simplify common scenarios */
   schema?: JSONSchema | null;
 }
 
@@ -36,6 +38,7 @@ export class LocalStorage {
   /**
    * Gets an item value in local storage
    * @param key The item's key
+   * @param options Current options include a JSON schema to validate the data
    * @returns The item's value if the key exists, null otherwise, wrapped in an RxJS Observable
    */
   getItem(key: string, options: LSGetItemOptions &

--- a/projects/ngx-pwa/local-storage/src/lib/lib.service.ts
+++ b/projects/ngx-pwa/local-storage/src/lib/lib.service.ts
@@ -3,7 +3,10 @@ import { Observable, throwError, of } from 'rxjs';
 import { mergeMap } from 'rxjs/operators';
 
 import { LocalDatabase } from './databases/local-database';
-import { JSONSchema } from './validation/json-schema';
+import {
+  JSONSchema, JSONSchemaString, JSONSchemaNumeric, JSONSchemaBoolean,
+  JSONSchemaArrayOf, JSONSchemaConstOf, JSONSchemaEnumOf
+} from './validation/json-schema';
 import { JSONValidator } from './validation/json-validator';
 
 export interface LSGetItemOptions {
@@ -35,6 +38,18 @@ export class LocalStorage {
    * @param key The item's key
    * @returns The item's value if the key exists, null otherwise, wrapped in an RxJS Observable
    */
+  getItem(key: string, options: LSGetItemOptions &
+    { schema: JSONSchemaBoolean | JSONSchemaConstOf<boolean> }): Observable<boolean | null>;
+  getItem(key: string, options: LSGetItemOptions &
+    { schema: JSONSchemaNumeric | JSONSchemaConstOf<number> | JSONSchemaEnumOf<number> }): Observable<number | null>;
+  getItem(key: string, options: LSGetItemOptions &
+    { schema: JSONSchemaString | JSONSchemaConstOf<string> | JSONSchemaEnumOf<string> }): Observable<string | null>;
+  getItem(key: string, options: LSGetItemOptions &
+    { schema: JSONSchemaArrayOf<JSONSchemaBoolean> }): Observable<boolean[] | null>;
+  getItem(key: string, options: LSGetItemOptions &
+    { schema: JSONSchemaArrayOf<JSONSchemaNumeric> }): Observable<number[] | null>;
+  getItem(key: string, options: LSGetItemOptions &
+    { schema: JSONSchemaArrayOf<JSONSchemaString> }): Observable<string[] | null>;
   getItem<T = any>(key: string, options: LSGetItemOptions & { schema: JSONSchema }): Observable<T | null>;
   getItem<T = any>(key: string, options?: LSGetItemOptions): Observable<unknown>;
   getItem<T = any>(key: string, options = this.getItemOptionsDefault) {

--- a/projects/ngx-pwa/local-storage/src/lib/validation/constants.ts
+++ b/projects/ngx-pwa/local-storage/src/lib/validation/constants.ts
@@ -1,7 +1,13 @@
-import { JSONSchemaBoolean, JSONSchemaNumeric, JSONSchemaString } from './json-schema';
+import { JSONSchemaBoolean, JSONSchemaNumeric, JSONSchemaString, JSONSchemaArrayOf } from './json-schema';
 
 /* Schemas for primitive types */
 export const SCHEMA_BOOLEAN: JSONSchemaBoolean = { type: 'boolean' };
 export const SCHEMA_INTEGER: JSONSchemaNumeric = { type: 'integer' };
 export const SCHEMA_NUMBER: JSONSchemaNumeric = { type: 'number' };
 export const SCHEMA_STRING: JSONSchemaString = { type: 'string' };
+
+/* Schemas for basic arrays */
+export const SCHEMA_ARRAY_OF_BOOLEANS: JSONSchemaArrayOf<JSONSchemaBoolean> = { items: SCHEMA_BOOLEAN };
+export const SCHEMA_ARRAY_OF_INTEGERS: JSONSchemaArrayOf<JSONSchemaNumeric> = { items: SCHEMA_INTEGER };
+export const SCHEMA_ARRAY_OF_NUMBERS: JSONSchemaArrayOf<JSONSchemaNumeric> = { items: SCHEMA_NUMBER };
+export const SCHEMA_ARRAY_OF_STRINGS: JSONSchemaArrayOf<JSONSchemaString> = { items: SCHEMA_STRING };

--- a/projects/ngx-pwa/local-storage/src/lib/validation/constants.ts
+++ b/projects/ngx-pwa/local-storage/src/lib/validation/constants.ts
@@ -1,0 +1,7 @@
+import { JSONSchemaBoolean, JSONSchemaNumeric, JSONSchemaString } from './json-schema';
+
+/* Schemas for primitive types */
+export const SCHEMA_BOOLEAN: JSONSchemaBoolean = { type: 'boolean' };
+export const SCHEMA_INTEGER: JSONSchemaNumeric = { type: 'integer' };
+export const SCHEMA_NUMBER: JSONSchemaNumeric = { type: 'number' };
+export const SCHEMA_STRING: JSONSchemaString = { type: 'string' };

--- a/projects/ngx-pwa/local-storage/src/lib/validation/constants.ts
+++ b/projects/ngx-pwa/local-storage/src/lib/validation/constants.ts
@@ -7,7 +7,19 @@ export const SCHEMA_NUMBER: JSONSchemaNumeric = { type: 'number' };
 export const SCHEMA_STRING: JSONSchemaString = { type: 'string' };
 
 /* Schemas for basic arrays */
-export const SCHEMA_ARRAY_OF_BOOLEANS: JSONSchemaArrayOf<JSONSchemaBoolean> = { items: SCHEMA_BOOLEAN };
-export const SCHEMA_ARRAY_OF_INTEGERS: JSONSchemaArrayOf<JSONSchemaNumeric> = { items: SCHEMA_INTEGER };
-export const SCHEMA_ARRAY_OF_NUMBERS: JSONSchemaArrayOf<JSONSchemaNumeric> = { items: SCHEMA_NUMBER };
-export const SCHEMA_ARRAY_OF_STRINGS: JSONSchemaArrayOf<JSONSchemaString> = { items: SCHEMA_STRING };
+export const SCHEMA_ARRAY_OF_BOOLEANS: JSONSchemaArrayOf<JSONSchemaBoolean> = {
+  type: 'array',
+  items: SCHEMA_BOOLEAN
+};
+export const SCHEMA_ARRAY_OF_INTEGERS: JSONSchemaArrayOf<JSONSchemaNumeric> = {
+  type: 'array',
+  items: SCHEMA_INTEGER
+};
+export const SCHEMA_ARRAY_OF_NUMBERS: JSONSchemaArrayOf<JSONSchemaNumeric> = {
+  type: 'array',
+  items: SCHEMA_NUMBER
+};
+export const SCHEMA_ARRAY_OF_STRINGS: JSONSchemaArrayOf<JSONSchemaString> = {
+  type: 'array',
+  items: SCHEMA_STRING
+};

--- a/projects/ngx-pwa/local-storage/src/lib/validation/json-schema.ts
+++ b/projects/ngx-pwa/local-storage/src/lib/validation/json-schema.ts
@@ -1,3 +1,6 @@
+/**
+ * Prefer `JSONSchemaConstOf<T>`, which is more precise
+ */
 export interface JSONSchemaConst {
 
   /**
@@ -8,6 +11,15 @@ export interface JSONSchemaConst {
 
 }
 
+export interface JSONSchemaConstOf<T extends string | number | boolean> extends JSONSchemaConst {
+
+  const: T;
+
+}
+
+/**
+ * Prefer `JSONSchemaEnumOf<T>`, which is more precise
+ */
 export interface JSONSchemaEnum {
 
   /**
@@ -15,6 +27,12 @@ export interface JSONSchemaEnum {
    * Can't be an object or array, as two objects or arrays are never equal.
    */
   enum: (string | number | boolean | null)[];
+
+}
+
+export interface JSONSchemaEnumOf<T extends string | number> extends JSONSchemaEnum {
+
+  enum: T[];
 
 }
 
@@ -95,6 +113,10 @@ export interface JSONSchemaNumeric {
 
 }
 
+/**
+ * For basic arrays (of booleans, integers, numbers or strings),
+ * prefer `JSONSchemaArrayOf<T>`, which is more precise
+ */
 export interface JSONSchemaArray {
 
   /**
@@ -124,6 +146,12 @@ export interface JSONSchemaArray {
    * Check if an array only have unique values.
    */
   uniqueItems?: boolean;
+
+}
+
+export interface JSONSchemaArrayOf<T extends JSONSchemaBoolean | JSONSchemaNumeric | JSONSchemaString> extends JSONSchemaArray {
+
+  items: T;
 
 }
 

--- a/projects/ngx-pwa/local-storage/src/lib/validation/json-schema.ts
+++ b/projects/ngx-pwa/local-storage/src/lib/validation/json-schema.ts
@@ -180,6 +180,8 @@ export interface JSONSchemaObject {
 
 /**
  * Subset of the JSON Schema.
+ * Due to limitations in TypeScript, prefer specific interfaces (`JSONSchemaBoolean`, `JSONSchemaString`...)
+ * as autocompletion and checks will be more accurate.
  * Types are enforced to validate everything:
  * each value MUST have just ONE of either 'type' or 'properties' or 'items' or 'const' or 'enum'.
  * Therefore, unlike the spec, booleans are not allowed as schemas.

--- a/projects/ngx-pwa/local-storage/src/lib/validation/json-schema.ts
+++ b/projects/ngx-pwa/local-storage/src/lib/validation/json-schema.ts
@@ -151,6 +151,8 @@ export interface JSONSchemaArray {
 
 export interface JSONSchemaArrayOf<T extends JSONSchemaBoolean | JSONSchemaNumeric | JSONSchemaString> extends JSONSchemaArray {
 
+  type: 'array';
+
   items: T;
 
 }

--- a/projects/ngx-pwa/local-storage/src/lib/validation/json-validation.spec.ts
+++ b/projects/ngx-pwa/local-storage/src/lib/validation/json-validation.spec.ts
@@ -1,8 +1,9 @@
 import { JSONValidator } from './json-validator';
 import {
   JSONSchemaConst, JSONSchemaEnum, JSONSchemaBoolean, JSONSchemaNull,
-  JSONSchemaNumeric, JSONSchemaString, JSONSchemaObject, JSONSchemaArray
+  JSONSchemaNumeric, JSONSchemaString, JSONSchemaObject, JSONSchemaArray, JSONSchema
 } from './json-schema';
+import { SCHEMA_BOOLEAN, SCHEMA_STRING, SCHEMA_NUMBER, SCHEMA_INTEGER } from './constants';
 
 describe(`JSONValidator`, () => {
 
@@ -20,7 +21,8 @@ describe(`JSONValidator`, () => {
 
       expect(() => {
 
-        jsonValidator.validate({ test: 'test' }, { properties: { test: { type: 'string' } }, additionalProperties: true });
+        // TODO: remove casting when T3.2 issue is fixed
+        jsonValidator.validate({ test: 'test' }, { properties: { test: { type: 'string' } }, additionalProperties: true } as JSONSchema);
 
       }).not.toThrow();
 
@@ -188,6 +190,10 @@ describe(`JSONValidator`, () => {
 
       expect(test).toBe(true);
 
+      const test2 = jsonValidator.validate(true, SCHEMA_BOOLEAN);
+
+      expect(test2).toBe(true);
+
     });
 
     it(`should return true on a false value with a boolean type`, () => {
@@ -195,6 +201,10 @@ describe(`JSONValidator`, () => {
       const test = jsonValidator.validate(false, { type: 'boolean' } as JSONSchemaBoolean);
 
       expect(test).toBe(true);
+
+      const test2 = jsonValidator.validate(false, SCHEMA_BOOLEAN);
+
+      expect(test2).toBe(true);
 
     });
 
@@ -223,6 +233,22 @@ describe(`JSONValidator`, () => {
       const test = jsonValidator.validate('test', { type: 'string' } as JSONSchemaString);
 
       expect(test).toBe(true);
+
+      const test2 = jsonValidator.validate('test', SCHEMA_STRING);
+
+      expect(test2).toBe(true);
+
+    });
+
+    it(`should return false on a string value with a mismatched type`, () => {
+
+      const test = jsonValidator.validate(10, { type: 'string' } as JSONSchemaString);
+
+      expect(test).toBe(false);
+
+      const test2 = jsonValidator.validate(10, SCHEMA_STRING);
+
+      expect(test2).toBe(false);
 
     });
 
@@ -324,6 +350,10 @@ describe(`JSONValidator`, () => {
 
       expect(test).toBe(true);
 
+      const test2 = jsonValidator.validate(10, SCHEMA_NUMBER);
+
+      expect(test2).toBe(true);
+
     });
 
     it(`should return true on a decimal value with a number type`, () => {
@@ -331,6 +361,10 @@ describe(`JSONValidator`, () => {
       const test = jsonValidator.validate(10.1, { type: 'number' } as JSONSchemaNumeric);
 
       expect(test).toBe(true);
+
+      const test2 = jsonValidator.validate(10.1, SCHEMA_NUMBER);
+
+      expect(test2).toBe(true);
 
     });
 
@@ -340,6 +374,10 @@ describe(`JSONValidator`, () => {
 
       expect(test).toBe(true);
 
+      const test2 = jsonValidator.validate(10, SCHEMA_INTEGER);
+
+      expect(test2).toBe(true);
+
     });
 
     it(`should return false on a decimal value with an integer type`, () => {
@@ -347,6 +385,10 @@ describe(`JSONValidator`, () => {
       const test = jsonValidator.validate(10.1, { type: 'integer' } as JSONSchemaNumeric);
 
       expect(test).toBe(false);
+
+      const test2 = jsonValidator.validate(10.1, SCHEMA_INTEGER);
+
+      expect(test2).toBe(false);
 
     });
 

--- a/projects/ngx-pwa/local-storage/src/public_api.ts
+++ b/projects/ngx-pwa/local-storage/src/public_api.ts
@@ -4,7 +4,8 @@
 
 export {
   JSONSchema, JSONSchemaConst, JSONSchemaEnum, JSONSchemaBoolean,
-  JSONSchemaNumeric, JSONSchemaString, JSONSchemaArray, JSONSchemaObject
+  JSONSchemaNumeric, JSONSchemaString, JSONSchemaArray, JSONSchemaObject,
+  JSONSchemaArrayOf, JSONSchemaEnumOf, JSONSchemaConstOf
 } from './lib/validation/json-schema';
 export { LocalDatabase } from './lib/databases/local-database';
 export { IndexedDBDatabase } from './lib/databases/indexeddb-database';
@@ -13,4 +14,7 @@ export { MockLocalDatabase } from './lib/databases/mock-local-database';
 export { JSONValidator } from './lib/validation/json-validator';
 export { LSGetItemOptions, LocalStorage } from './lib/lib.service';
 export { localStorageProviders, LocalStorageProvidersConfig, LOCAL_STORAGE_PREFIX } from './lib/tokens';
-export { SCHEMA_BOOLEAN, SCHEMA_INTEGER, SCHEMA_NUMBER, SCHEMA_STRING } from './lib/validation/constants';
+export {
+  SCHEMA_BOOLEAN, SCHEMA_INTEGER, SCHEMA_NUMBER, SCHEMA_STRING,
+  SCHEMA_ARRAY_OF_BOOLEANS, SCHEMA_ARRAY_OF_INTEGERS, SCHEMA_ARRAY_OF_NUMBERS, SCHEMA_ARRAY_OF_STRINGS
+} from './lib/validation/constants';

--- a/projects/ngx-pwa/local-storage/src/public_api.ts
+++ b/projects/ngx-pwa/local-storage/src/public_api.ts
@@ -13,3 +13,4 @@ export { MockLocalDatabase } from './lib/databases/mock-local-database';
 export { JSONValidator } from './lib/validation/json-validator';
 export { LSGetItemOptions, LocalStorage } from './lib/lib.service';
 export { localStorageProviders, LocalStorageProvidersConfig, LOCAL_STORAGE_PREFIX } from './lib/tokens';
+export { SCHEMA_BOOLEAN, SCHEMA_INTEGER, SCHEMA_NUMBER, SCHEMA_STRING } from './lib/validation/constants';


### PR DESCRIPTION
- Added predefined constants for basic JSON schemas to simplify validation:
  - `SCHEMA_BOOLEAN` (shortcut for: `{ type: 'boolean' }`)
  - `SCHEMA_INTEGER` (shortcut for: `{ type: 'integer' }`)
  - `SCHEMA_NUMBER` (shortcut for: `{ type: 'number' }`)
  - `SCHEMA_STRING` (shortcut for: `{ type: 'string' }`)
  - `SCHEMA_ARRAY_OF_BOOLEANS` (shortcut for: `{ items: { type: 'boolean' } }`)
  - `SCHEMA_ARRAY_OF_INTEGER` (shortcut for: `{ items: { type: 'integer' } }`)
  - `SCHEMA_ARRAY_OF_NUMBER` (shortcut for: `{ items: { type: 'number' } }`)
  - `SCHEMA_ARRAY_OF_STRINGS` (shortcut for: `{ items: { type: 'string' } }`)

This is especially useful for advanced types (arrays, objects, nested types),
to avoid TypeScript limitations.

- For the same types as above, the result type is now automatically infered,
meaning you don't need to cast anymore!

Before v7.5:
```typescript
this.localStorage.getItem('test', { schema: { type: 'string' } })
.subscribe((result) => {
  result; // type: any :(
});

this.localStorage.getItem<string>('test', { schema: { type: 'string' } })
.subscribe((result) => {
  result; // type: string :)
});
```

From v7.5:
```typescript
import { SCHEMA_STRING } from '@ngx-pwa/local-storage';

this.localStorage.getItem('test', { schema: SCHEMA_STRING })
.subscribe((result) => {
  result; // type: string :D
});
```

- Added better interfaces for some JSON schemas:
  - `JSONSchemaArrayOf<T>`
  - `JSONSchemaConstOf<T>`
  - `JSONSchemaEnumOf<T>`

Why?
- simplify validation for everyone (no more casting in most cases)
- ease migration path to v7
- makes the TS 3.2 issue (see #64) disappear for most cases (except for objects or nested types)

See documentation included in the PR.