### PR TITLE
feat: .length as alias of .size

### DIFF
--- a/projects/ngx-pwa/local-storage/src/lib/lib.service.spec.ts
+++ b/projects/ngx-pwa/local-storage/src/lib/lib.service.spec.ts
@@ -189,6 +189,48 @@ function tests(localStorageService: LocalStorage) {
 
   });
 
+  it('should count the size of items stored with alias', (done: DoneFn) => {
+
+    localStorageService.length.subscribe((length0) => {
+
+      expect(length0).toBe(0);
+
+      localStorageService.setItem('test1', 'test').subscribe(() => {
+
+        localStorageService.length.subscribe((length1) => {
+
+          expect(length1).toBe(1);
+
+          localStorageService.setItem('test2', 'test').subscribe(() => {
+
+            localStorageService.length.subscribe((length2) => {
+
+              expect(length2).toBe(2);
+
+              localStorageService.clear().subscribe(() => {
+
+                localStorageService.length.subscribe((length3) => {
+
+                  expect(length3).toBe(0);
+
+                  done();
+
+                });
+
+              });
+
+            });
+
+          });
+
+        });
+
+      });
+
+    });
+
+  });
+
   it('should get keys', (done: DoneFn) => {
 
     const index1 = 'index1';

--- a/projects/ngx-pwa/local-storage/src/lib/lib.service.ts
+++ b/projects/ngx-pwa/local-storage/src/lib/lib.service.ts
@@ -24,6 +24,17 @@ export class LocalStorage {
 
   }
 
+  /**
+   * Alias. Prefer .size
+   * @alias
+   * @ignore
+   */
+  get length(): Observable<number> {
+
+    return this.size;
+
+  }
+
   protected readonly getItemOptionsDefault: LSGetItemOptions = {
     schema: null
   };


### PR DESCRIPTION
Last versions added `Map`-like API, with `.has()`, `.keys()` and `.size`.

But initially, this lib reproduces the `localStorage` API where `.length` is available.

So this PR add `.length` as an alias of `.size`.