### PR TITLE
feat: new IDB storing behavior with no wrapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ import { LocalStorage } from '@ngx-pwa/local-storage';
 @Injectable()
 export class YourService {
 
-  constructor(protected localStorage: LocalStorage) {}
+  constructor(private localStorage: LocalStorage) {}
 
 }
 ```

--- a/projects/ngx-pwa/local-storage/src/lib/databases/indexeddb-database.ts
+++ b/projects/ngx-pwa/local-storage/src/lib/databases/indexeddb-database.ts
@@ -67,7 +67,7 @@ export class IndexedDBDatabase implements LocalDatabase {
    * @param compatibilityPriorToV8 Flag to keep storing behavior prior to version 8
    */
   constructor(
-    @Inject(PREFIX) prefix: string | null = null,
+    @Inject(PREFIX) prefix = '',
     @Inject(IDB_DB_NAME) dbName = DEFAULT_IDB_DB_NAME,
     @Inject(IDB_STORE_NAME) storeName = DEFAULT_IDB_STORE_NAME,
     @Inject(COMPATIBILITY_PRIOR_TO_V8) compatibilityPriorToV8 = false,

--- a/projects/ngx-pwa/local-storage/src/lib/databases/indexeddb-database.ts
+++ b/projects/ngx-pwa/local-storage/src/lib/databases/indexeddb-database.ts
@@ -59,6 +59,7 @@ export class IndexedDBDatabase implements LocalDatabase {
 
   }
 
+  // TODO: revert compatibilityPriorToV8 to true by default if ng update is not possible
   /**
    * Constructor params are provided by Angular (but can also be passed manually in tests)
    * @param prefix Optional user prefix to avoid collision for multiple apps on the same subdomain

--- a/projects/ngx-pwa/local-storage/src/lib/databases/indexeddb-database.ts
+++ b/projects/ngx-pwa/local-storage/src/lib/databases/indexeddb-database.ts
@@ -62,7 +62,6 @@ export class IndexedDBDatabase implements LocalDatabase {
 
   }
 
-  // TODO: revert compatibilityPriorToV8 to true by default if ng update is not possible
   /**
    * Constructor params are provided by Angular (but can also be passed manually in tests)
    * @param prefix Optional user prefix to avoid collision for multiple apps on the same subdomain

--- a/projects/ngx-pwa/local-storage/src/lib/databases/indexeddb-database.ts
+++ b/projects/ngx-pwa/local-storage/src/lib/databases/indexeddb-database.ts
@@ -3,7 +3,10 @@ import { Observable, ReplaySubject, fromEvent, of, throwError, race } from 'rxjs
 import { map, mergeMap, first, tap, filter } from 'rxjs/operators';
 
 import { LocalDatabase } from './local-database';
-import { PREFIX, IDB_DB_NAME, DEFAULT_IDB_DB_NAME, IDB_STORE_NAME, DEFAULT_IDB_STORE_NAME, COMPATIBILITY_PRIOR_TO_V8 } from '../tokens';
+import {
+  PREFIX, IDB_DB_NAME, DEFAULT_IDB_DB_NAME, IDB_STORE_NAME, DEFAULT_IDB_STORE_NAME,
+  COMPATIBILITY_PRIOR_TO_V8, DEFAULT_PREFIX, DEFAULT_COMPATIBILITY_PRIOR_TO_V8
+} from '../tokens';
 import { IDBBrokenError } from '../exceptions';
 
 @Injectable({
@@ -68,10 +71,10 @@ export class IndexedDBDatabase implements LocalDatabase {
    * @param compatibilityPriorToV8 Flag to keep storing behavior prior to version 8
    */
   constructor(
-    @Inject(PREFIX) prefix = '',
+    @Inject(PREFIX) prefix = DEFAULT_PREFIX,
     @Inject(IDB_DB_NAME) dbName = DEFAULT_IDB_DB_NAME,
     @Inject(IDB_STORE_NAME) storeName = DEFAULT_IDB_STORE_NAME,
-    @Inject(COMPATIBILITY_PRIOR_TO_V8) compatibilityPriorToV8 = false,
+    @Inject(COMPATIBILITY_PRIOR_TO_V8) compatibilityPriorToV8 = DEFAULT_COMPATIBILITY_PRIOR_TO_V8,
   ) {
 
     /* Initialize `indexedDB` database name, with prefix if provided by the user */

--- a/projects/ngx-pwa/local-storage/src/lib/databases/indexeddb-database.ts
+++ b/projects/ngx-pwa/local-storage/src/lib/databases/indexeddb-database.ts
@@ -82,7 +82,7 @@ export class IndexedDBDatabase implements LocalDatabase {
     this.compatibilityPriorToV8 = compatibilityPriorToV8;
 
     /* Creating the RxJS ReplaySubject */
-    this.database = new ReplaySubject<IDBDatabase>();
+    this.database = new ReplaySubject<IDBDatabase>(1);
 
     /* Connect to `indexedDB`, with prefix if provided by the user */
     this.connect();

--- a/projects/ngx-pwa/local-storage/src/lib/databases/local-database.ts
+++ b/projects/ngx-pwa/local-storage/src/lib/databases/local-database.ts
@@ -1,4 +1,4 @@
-import { Injectable, PLATFORM_ID, Optional } from '@angular/core';
+import { Injectable, PLATFORM_ID } from '@angular/core';
 import { isPlatformBrowser, isPlatformWorkerApp, isPlatformWorkerUi } from '@angular/common';
 import { Observable } from 'rxjs';
 
@@ -13,7 +13,7 @@ import { PREFIX } from '../tokens';
  * @param prefix Optional user prefix to avoid collision for multiple apps on the same subdomain
  * @see https://github.com/cyrilletuzi/angular-async-local-storage/blob/master/docs/BROWSERS_SUPPORT.md
  */
-export function localDatabaseFactory(platformId: Object, prefix: string | null): LocalDatabase {
+export function localDatabaseFactory(platformId: Object, prefix: string): LocalDatabase {
 
   // Do not explicit `window` here, as the global object is not the same in web workers
   if ((isPlatformBrowser(platformId) || isPlatformWorkerApp(platformId) || isPlatformWorkerUi(platformId))
@@ -63,7 +63,7 @@ export function localDatabaseFactory(platformId: Object, prefix: string | null):
   useFactory: localDatabaseFactory,
   deps: [
     PLATFORM_ID,
-    [new Optional(), PREFIX]
+    PREFIX
   ]
 })
 export abstract class LocalDatabase {

--- a/projects/ngx-pwa/local-storage/src/lib/databases/localstorage-database.ts
+++ b/projects/ngx-pwa/local-storage/src/lib/databases/localstorage-database.ts
@@ -12,7 +12,7 @@ export class LocalStorageDatabase implements LocalDatabase {
   /**
    * Optional user prefix to avoid collision for multiple apps on the same subdomain
    */
-  private prefix = '';
+  private readonly prefix: string;
 
   /**
    * Number of items in `localStorage`
@@ -30,9 +30,7 @@ export class LocalStorageDatabase implements LocalDatabase {
    */
   constructor(@Inject(PREFIX) userPrefix = '') {
 
-    if (userPrefix) {
-      this.prefix = `${userPrefix}_`;
-    }
+    this.prefix = userPrefix ? `${userPrefix}_` : '';
 
   }
 

--- a/projects/ngx-pwa/local-storage/src/lib/databases/localstorage-database.ts
+++ b/projects/ngx-pwa/local-storage/src/lib/databases/localstorage-database.ts
@@ -28,7 +28,7 @@ export class LocalStorageDatabase implements LocalDatabase {
    * Constructor params are provided by Angular (but can also be passed manually in tests)
    * @param prefix Optional user prefix to avoid collision for multiple apps on the same subdomain
    */
-  constructor(@Inject(PREFIX) userPrefix: string | null = null) {
+  constructor(@Inject(PREFIX) userPrefix = '') {
 
     if (userPrefix) {
       this.prefix = `${userPrefix}_`;

--- a/projects/ngx-pwa/local-storage/src/lib/databases/localstorage-database.ts
+++ b/projects/ngx-pwa/local-storage/src/lib/databases/localstorage-database.ts
@@ -1,4 +1,4 @@
-import { Injectable, Optional, Inject } from '@angular/core';
+import { Injectable, Inject } from '@angular/core';
 import { Observable, of, throwError } from 'rxjs';
 
 import { LocalDatabase } from './local-database';
@@ -12,7 +12,7 @@ export class LocalStorageDatabase implements LocalDatabase {
   /**
    * Optional user prefix to avoid collision for multiple apps on the same subdomain
    */
-  protected prefix = '';
+  private prefix = '';
 
   /**
    * Number of items in `localStorage`
@@ -28,7 +28,7 @@ export class LocalStorageDatabase implements LocalDatabase {
    * Constructor params are provided by Angular (but can also be passed manually in tests)
    * @param prefix Optional user prefix to avoid collision for multiple apps on the same subdomain
    */
-  constructor(@Optional() @Inject(PREFIX) userPrefix: string | null = null) {
+  constructor(@Inject(PREFIX) userPrefix: string | null = null) {
 
     if (userPrefix) {
       this.prefix = `${userPrefix}_`;

--- a/projects/ngx-pwa/local-storage/src/lib/databases/localstorage-database.ts
+++ b/projects/ngx-pwa/local-storage/src/lib/databases/localstorage-database.ts
@@ -28,9 +28,9 @@ export class LocalStorageDatabase implements LocalDatabase {
    * Constructor params are provided by Angular (but can also be passed manually in tests)
    * @param prefix Optional user prefix to avoid collision for multiple apps on the same subdomain
    */
-  constructor(@Inject(PREFIX) userPrefix = '') {
+  constructor(@Inject(PREFIX) prefix = '') {
 
-    this.prefix = userPrefix ? `${userPrefix}_` : '';
+    this.prefix = prefix ? `${prefix}_` : '';
 
   }
 

--- a/projects/ngx-pwa/local-storage/src/lib/databases/localstorage-database.ts
+++ b/projects/ngx-pwa/local-storage/src/lib/databases/localstorage-database.ts
@@ -2,7 +2,7 @@ import { Injectable, Inject } from '@angular/core';
 import { Observable, of, throwError } from 'rxjs';
 
 import { LocalDatabase } from './local-database';
-import { PREFIX } from '../tokens';
+import { PREFIX, DEFAULT_PREFIX } from '../tokens';
 
 @Injectable({
   providedIn: 'root'
@@ -28,9 +28,10 @@ export class LocalStorageDatabase implements LocalDatabase {
    * Constructor params are provided by Angular (but can also be passed manually in tests)
    * @param prefix Optional user prefix to avoid collision for multiple apps on the same subdomain
    */
-  constructor(@Inject(PREFIX) prefix = '') {
+  constructor(@Inject(PREFIX) prefix = DEFAULT_PREFIX) {
 
-    this.prefix = prefix ? `${prefix}_` : '';
+    /* Add `_` after prefix only if not empty */
+    this.prefix = prefix ? `${prefix}_` : prefix;
 
   }
 

--- a/projects/ngx-pwa/local-storage/src/lib/lib.service.spec.ts
+++ b/projects/ngx-pwa/local-storage/src/lib/lib.service.spec.ts
@@ -768,7 +768,7 @@ describe('IndexedDB', () => {
 
 describe('IndexedDB with compatibilityPriorToV8', () => {
 
-  const localStorageService = new LocalStorage(new IndexedDBDatabase(null, undefined, undefined, true), new JSONValidator());
+  const localStorageService = new LocalStorage(new IndexedDBDatabase(undefined, undefined, undefined, true), new JSONValidator());
 
   beforeEach((done) => {
 
@@ -847,7 +847,7 @@ describe('IndexedDB with custom database and store names', () => {
   const dbName = 'dBcustom';
   const storeName = 'storeCustom';
 
-  const localStorageService = new LocalStorage(new IndexedDBDatabase(null, dbName, storeName), new JSONValidator());
+  const localStorageService = new LocalStorage(new IndexedDBDatabase(undefined, dbName, storeName), new JSONValidator());
 
   beforeEach((done) => {
 

--- a/projects/ngx-pwa/local-storage/src/lib/lib.service.spec.ts
+++ b/projects/ngx-pwa/local-storage/src/lib/lib.service.spec.ts
@@ -738,7 +738,7 @@ describe('IndexedDB', () => {
 
           request.addEventListener('success', () => {
 
-            expect(request.result).toEqual({ value });
+            expect(request.result).toEqual(value);
 
             done();
 
@@ -766,21 +766,32 @@ describe('IndexedDB', () => {
 
 });
 
+describe('IndexedDB with compatibilityPriorToV8', () => {
+
+  const localStorageService = new LocalStorage(new IndexedDBDatabase(null, undefined, undefined, true), new JSONValidator());
+
+  beforeEach((done) => {
+
+    /* Clear `localStorage` for some browsers private mode which fallbacks to `localStorage` */
+    localStorage.clear();
+
+    clearIndexedDB(done);
+
+  });
+
+  tests(localStorageService);
+
+});
+
 describe('localStorage and a prefix', () => {
 
   const prefix = 'myapp';
 
   it('check prefix', () => {
 
-    class LocalStorageDatabasePrefix extends LocalStorageDatabase {
-      getPrefix() {
-        return this.prefix;
-      }
-    }
+    const localStorageServicePrefix = new LocalStorageDatabase(prefix);
 
-    const localStorageServicePrefix = new LocalStorageDatabasePrefix(prefix);
-
-    expect(localStorageServicePrefix.getPrefix()).toBe(`${prefix}_`);
+    expect(localStorageServicePrefix['prefix']).toBe(`${prefix}_`);
 
   });
 
@@ -800,15 +811,9 @@ describe('IndexedDB and a prefix', () => {
 
   it('check prefix', () => {
 
-    class IndexedDBDatabasePrefix extends IndexedDBDatabase {
-      getDbBame() {
-        return this.dbName;
-      }
-    }
+    const indexedDBService = new IndexedDBDatabase(prefix);
 
-    const indexedDBService = new IndexedDBDatabasePrefix(prefix);
-
-    expect(indexedDBService.getDbBame()).toBe(`${prefix}_${DEFAULT_IDB_DB_NAME}`);
+    expect(indexedDBService['dbName']).toBe(`${prefix}_${DEFAULT_IDB_DB_NAME}`);
 
   });
 
@@ -816,17 +821,9 @@ describe('IndexedDB and a prefix', () => {
 
     const dbName = 'customDb';
 
-    class IndexedDBDatabasePrefix extends IndexedDBDatabase {
+    const indexedDBService = new IndexedDBDatabase(prefix, dbName);
 
-      getDbBame() {
-        return this.dbName;
-      }
-
-    }
-
-    const indexedDBService = new IndexedDBDatabasePrefix(prefix, dbName);
-
-    expect(indexedDBService.getDbBame()).toBe(`${prefix}_${dbName}`);
+    expect(indexedDBService['dbName']).toBe(`${prefix}_${dbName}`);
 
   });
 

--- a/projects/ngx-pwa/local-storage/src/lib/lib.service.ts
+++ b/projects/ngx-pwa/local-storage/src/lib/lib.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Optional, Inject } from '@angular/core';
+import { Injectable, Inject } from '@angular/core';
 import { Observable, throwError, of, OperatorFunction } from 'rxjs';
 import { mergeMap, catchError } from 'rxjs/operators';
 
@@ -49,7 +49,7 @@ export class LocalStorage {
   constructor(
     private database: LocalDatabase,
     private jsonValidator: JSONValidator,
-    @Inject(PREFIX) private prefix: string | null = null,
+    @Inject(PREFIX) private prefix = '',
   ) {}
 
   /**

--- a/projects/ngx-pwa/local-storage/src/lib/lib.service.ts
+++ b/projects/ngx-pwa/local-storage/src/lib/lib.service.ts
@@ -49,7 +49,7 @@ export class LocalStorage {
   constructor(
     private database: LocalDatabase,
     private jsonValidator: JSONValidator,
-    @Optional() @Inject(PREFIX) protected prefix: string | null = null,
+    @Inject(PREFIX) private prefix: string | null = null,
   ) {}
 
   /**

--- a/projects/ngx-pwa/local-storage/src/lib/tokens.ts
+++ b/projects/ngx-pwa/local-storage/src/lib/tokens.ts
@@ -36,6 +36,7 @@ export const IDB_STORE_NAME = new InjectionToken<string>('localStorageIDBStoreNa
   factory: () => DEFAULT_IDB_STORE_NAME
 });
 
+// TODO: revert to true by default if ng update is not possible
 /**
  * Token to keep storing behavior prior to version 8.
  */

--- a/projects/ngx-pwa/local-storage/src/lib/tokens.ts
+++ b/projects/ngx-pwa/local-storage/src/lib/tokens.ts
@@ -1,17 +1,12 @@
 import { InjectionToken, Provider } from '@angular/core';
 
 /**
- * Internal. Use the `localStorageProviders()` helper function to provide options.
+ * Token to provide a prefix to avoid collision when multiple apps on the same subdomain.
  */
 export const PREFIX = new InjectionToken<string>('localStoragePrefix', {
   providedIn: 'root',
   factory: () => ''
 });
-
-/**
- * @deprecated Use the `localStorageProviders()` helper function to provide options. Will be removed in v9.
- */
-export const LOCAL_STORAGE_PREFIX = PREFIX;
 
 /**
  * Default name used for `indexedDB` database.
@@ -20,9 +15,9 @@ export const LOCAL_STORAGE_PREFIX = PREFIX;
 export const DEFAULT_IDB_DB_NAME = 'ngStorage';
 
 /**
- * Internal. Use the `localStorageProviders()` helper function to provide options.
+ * Token to provide `indexedDB` database name.
  */
-export const IDB_DB_NAME = new InjectionToken<string>('localStorageIndexedDbName', {
+export const IDB_DB_NAME = new InjectionToken<string>('localStorageIDBDBName', {
   providedIn: 'root',
   factory: () => DEFAULT_IDB_DB_NAME
 });
@@ -34,11 +29,19 @@ export const IDB_DB_NAME = new InjectionToken<string>('localStorageIndexedDbName
 export const DEFAULT_IDB_STORE_NAME = 'localStorage';
 
 /**
- * Internal. Use the `localStorageProviders()` helper function to provide options.
+ * Token to provide `indexedDB` store name.
  */
-export const IDB_STORE_NAME = new InjectionToken<string>('localStorageIndexedDbStoreName', {
+export const IDB_STORE_NAME = new InjectionToken<string>('localStorageIDBStoreName', {
   providedIn: 'root',
   factory: () => DEFAULT_IDB_STORE_NAME
+});
+
+/**
+ * Token to keep storing behavior prior to version 8.
+ */
+export const COMPATIBILITY_PRIOR_TO_V8 = new InjectionToken<boolean>('localStorageCompatibilityPriorToV8', {
+  providedIn: 'root',
+  factory: () => false
 });
 
 export interface LocalStorageProvidersConfig {
@@ -64,6 +67,13 @@ export interface LocalStorageProvidersConfig {
    */
   IDBStoreName?: string;
 
+  /**
+   * Flag to keep storing behavior prior to version 8.
+   * Not needed for new installs,
+   * **must be `true` for upgrades from versions prior to V8, otherwise previously stored data will be lost.**
+   */
+  compatibilityPriorToV8?: boolean;
+
 }
 
 /**
@@ -77,6 +87,7 @@ export function localStorageProviders(config: LocalStorageProvidersConfig): Prov
     config.prefix ? { provide: PREFIX, useValue: config.prefix } : [],
     config.IDBDBName ? { provide: IDB_DB_NAME, useValue: config.IDBDBName } : [],
     config.IDBStoreName ? { provide: IDB_STORE_NAME, useValue: config.IDBStoreName } : [],
+    config.compatibilityPriorToV8 ? { provide: COMPATIBILITY_PRIOR_TO_V8, useValue: config.compatibilityPriorToV8 } : [],
   ];
 
 }

--- a/projects/ngx-pwa/local-storage/src/lib/tokens.ts
+++ b/projects/ngx-pwa/local-storage/src/lib/tokens.ts
@@ -1,11 +1,17 @@
 import { InjectionToken, Provider } from '@angular/core';
 
 /**
+ * Default prefix.
+ * *Use only to avoid conflict in multiple apps on the same subdomain.*
+ */
+export const DEFAULT_PREFIX = '';
+
+/**
  * Token to provide a prefix to avoid collision when multiple apps on the same subdomain.
  */
 export const PREFIX = new InjectionToken<string>('localStoragePrefix', {
   providedIn: 'root',
-  factory: () => ''
+  factory: () => DEFAULT_PREFIX
 });
 
 /**
@@ -38,11 +44,16 @@ export const IDB_STORE_NAME = new InjectionToken<string>('localStorageIDBStoreNa
 
 // TODO: revert to true by default if ng update is not possible
 /**
+ * Default compatibility mode.
+ */
+export const DEFAULT_COMPATIBILITY_PRIOR_TO_V8 = false;
+
+/**
  * Token to keep storing behavior prior to version 8.
  */
 export const COMPATIBILITY_PRIOR_TO_V8 = new InjectionToken<boolean>('localStorageCompatibilityPriorToV8', {
   providedIn: 'root',
-  factory: () => false
+  factory: () => DEFAULT_COMPATIBILITY_PRIOR_TO_V8
 });
 
 export interface LocalStorageProvidersConfig {


### PR DESCRIPTION
Fixes #67.

Activating the new behavior as the default depends on adding support for automatic `ng update`, otherwise it would be too dangerous.