### PR TITLE
feat: remove xSubscribe() methods

### DIFF
--- a/projects/ngx-pwa/local-storage/src/lib/lib.service.ts
+++ b/projects/ngx-pwa/local-storage/src/lib/lib.service.ts
@@ -183,54 +183,6 @@ export class LocalStorage {
   }
 
   /**
-   * Set an item in storage, and auto-subscribe
-   * @param key The item's key
-   * @param data The item's value
-   * **WARNING: should be avoided in most cases, use this method only if these conditions are fulfilled:**
-   * - you don't need to manage the error callback (errors will silently fail),
-   * - you don't need to wait the operation to finish before the next one (remember, it's asynchronous).
-   */
-  setItemSubscribe(key: string, data: string | number | boolean | object): void {
-
-    this.setItem(key, data).subscribe({
-      next: () => {},
-      error: () => {},
-    });
-
-  }
-
-  /**
-   * Delete an item in storage, and auto-subscribe
-   * @param key The item's key
-   * **WARNING: should be avoided in most cases, use this method only if these conditions are fulfilled:**
-   * - you don't need to manage the error callback (errors will silently fail),
-   * - you don't need to wait the operation to finish before the next one (remember, it's asynchronous).
-   */
-   removeItemSubscribe(key: string): void {
-
-    this.removeItem(key).subscribe({
-      next: () => {},
-      error: () => {},
-    });
-
-  }
-
-  /**
-   * Delete all items in storage, and auto-subscribe
-   * **WARNING: should be avoided in most cases, use this method only if these conditions are fulfilled:**
-   * - you don't need to manage the error callback (errors will silently fail),
-   * - you don't need to wait the operation to finish before the next one (remember, it's asynchronous).
-   */
-  clearSubscribe(): void {
-
-    this.clear().subscribe({
-      next: () => {},
-      error: () => {},
-    });
-
-  }
-
-  /**
    * RxJS operator to catch if `indexedDB` is broken
    * @param operationCallback Callback with the operation to redo
    */


### PR DESCRIPTION
Auto-subscription methods were added for simplicity, but they were risky shortcuts because:
- potential errors are not managed,
- it can cause concurrency issues, especially given the average RxJS knowledge.

So `setItemSubscribe()`, `removeItemSubscribe()` and `clearSubscribe()` are removed: subscribe manually.