### PR TITLE
fix: catch error when all storages are blocked

### DIFF
--- a/docs/BROWSERS_SUPPORT.md
+++ b/docs/BROWSERS_SUPPORT.md
@@ -30,4 +30,7 @@ In some scenarios, `indexedDB`  is not available, so the lib fallbacks to (synch
 If these scenarios are a concern for you, it impacts what you can store.
 See the [serialization guide](./SERIALIZATION.md) for full details.
 
+Also, if the "Block all cookies" option has been enabled in the browser,
+then all storages are blocked. In this case, the lib will fallback to an in-memory storage.
+
 [Back to general documentation](../README.md)


### PR DESCRIPTION
When storage is fully disabled in browser (via the "Block all cookies" option), just trying to check `indexedDB` or `localStorage` variables causes a security exception, and all Angular code will fail.

So the lib is now catching the error, and fallbacks to in memory-storage in this case.

Fixes #118 