### PR TITLE
fix: fallback to memory storage when all storages are blocked, in all scenarios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This lib is fully documented and so you'll find detailed [migration guides](./MIGRATION.md).
 
+## 6.2.5 & 8.0.2 (2019-06-19)
+
+### Bug fix
+
+- Same fix as previous release, but makes it work for all browsers
+(fixes [#118](https://github.com/cyrilletuzi/angular-async-local-storage/issues/118))
+
 ## 6.2.4 & 8.0.1 (2019-06-05)
 
 ### Bug fix

--- a/projects/ngx-pwa/local-storage/src/lib/storages/storage-map.service.ts
+++ b/projects/ngx-pwa/local-storage/src/lib/storages/storage-map.service.ts
@@ -307,8 +307,25 @@ export class StorageMap {
       /* Check if `indexedDB` is broken based on error message (the specific error class seems to be lost in the process) */
       if ((error !== undefined) && (error !== null) && (error.message === IDB_BROKEN_ERROR)) {
 
-        /* Fallback to `localStorage` */
-        this.database = new LocalStorageDatabase(this.LSPrefix, this.oldPrefix);
+        /* When storage is fully disabled in browser (via the "Block all cookies" option),
+         * just trying to check `localStorage` variable causes a security exception.
+         * Prevents https://github.com/cyrilletuzi/angular-async-local-storage/issues/118
+         */
+        try {
+
+          if ('getItem' in localStorage) {
+
+            /* Fallback to `localStorage` if available */
+            this.database = new LocalStorageDatabase(this.LSPrefix, this.oldPrefix);
+
+          }
+
+        } catch {
+
+          /* Fallback to memory storage otherwise */
+          this.database = new MemoryDatabase();
+
+        }
 
         /* Redo the operation */
         return operationCallback();

--- a/projects/ngx-pwa/local-storage/src/lib/storages/storage-map.service.ts
+++ b/projects/ngx-pwa/local-storage/src/lib/storages/storage-map.service.ts
@@ -318,6 +318,11 @@ export class StorageMap {
             /* Fallback to `localStorage` if available */
             this.database = new LocalStorageDatabase(this.LSPrefix, this.oldPrefix);
 
+          } else {
+
+            /* Fallback to memory storage otherwise */
+            this.database = new MemoryDatabase();
+
           }
 
         } catch {


### PR DESCRIPTION
Follow up of #119, which was fixing the issue in Firefox only. Now it's fixed in Chrome too.

Fixes #118 
