### PR TITLE
tests: improve CI tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs: # a collection of steps
           command: npm ci
       - run: # run tests
           name: test
-          command: npm ci:nglatest
+          command: npm run ci:nglatest
   ng80:
     docker: # run the steps with Docker
       - image: circleci/node:10-browsers # ...with this image as the primary container; this is where all `steps` will run
@@ -43,7 +43,7 @@ jobs: # a collection of steps
           command: npm ci
       - run: # run tests
           name: test
-          command: npm ci:ngnext
+          command: npm run ci:ngnext
 workflows:
   version: 2
   test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,20 +5,14 @@ jobs: # a collection of steps
       - image: circleci/node:10 # ...with this image as the primary container; this is where all `steps` will run
     steps: # a collection of executable commands
       - checkout
-      - run:
-          name: install-npm-wee
-          command: npm ci
       - run: # run tests
           name: lint
-          command: npm run lint
+          command: npm ci && npm run lint
   nglatest:
     docker: # run the steps with Docker
       - image: circleci/node:10-browsers # ...with this image as the primary container; this is where all `steps` will run
     steps: # a collection of executable commands
       - checkout
-      - run:
-          name: install-npm-wee
-          command: npm ci
       - run: # run tests
           name: test
           command: npm run ci:nglatest
@@ -28,9 +22,6 @@ jobs: # a collection of steps
     steps: # a collection of executable commands
       - checkout
       - run:
-          name: install-npm-wee
-          command: npm ci
-      - run:
           name: test
           command: npm run ci:ng80
   ngnext:
@@ -38,9 +29,6 @@ jobs: # a collection of steps
       - image: circleci/node:10-browsers # ...with this image as the primary container; this is where all `steps` will run
     steps: # a collection of executable commands
       - checkout
-      - run:
-          name: install-npm-wee
-          command: npm ci
       - run: # run tests
           name: test
           command: npm run ci:ngnext

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,58 +5,50 @@ jobs: # a collection of steps
       - image: circleci/node:10 # ...with this image as the primary container; this is where all `steps` will run
     steps: # a collection of executable commands
       - checkout
-      - restore_cache: # special step to restore the dependency cache
-          # Read about caching dependencies: https://circleci.com/docs/2.0/caching/
-          key: dependency-cache-{{ checksum "package-lock.json" }}
       - run:
           name: install-npm-wee
-          command: npm install
-      - save_cache: # special step to save the dependency cache
-          key: dependency-cache-{{ checksum "package-lock.json" }}
-          paths:
-            - ./node_modules
+          command: npm ci
       - run: # run tests
           name: lint
           command: npm run lint
-  test:
+  nglatest:
     docker: # run the steps with Docker
       - image: circleci/node:10-browsers # ...with this image as the primary container; this is where all `steps` will run
     steps: # a collection of executable commands
       - checkout
-      - restore_cache: # special step to restore the dependency cache
-          # Read about caching dependencies: https://circleci.com/docs/2.0/caching/
-          key: dependency-cache-{{ checksum "package-lock.json" }}
       - run:
           name: install-npm-wee
-          command: npm install
-      - save_cache: # special step to save the dependency cache
-          key: dependency-cache-{{ checksum "package-lock.json" }}
-          paths:
-            - ./node_modules
+          command: npm ci
       - run: # run tests
           name: test
-          command: npm test && npm run test:ivy
+          command: npm ci:nglatest
   ng80:
     docker: # run the steps with Docker
       - image: circleci/node:10-browsers # ...with this image as the primary container; this is where all `steps` will run
     steps: # a collection of executable commands
       - checkout
-      - restore_cache: # special step to restore the dependency cache
-          # Read about caching dependencies: https://circleci.com/docs/2.0/caching/
-          key: dependency-cache-{{ checksum "package-lock.json" }}
       - run:
           name: install-npm-wee
-          command: npm install
+          command: npm ci
       - run:
-          name: downgrade
+          name: test
           command: npm run ci:ng80
+  ngnext:
+    docker: # run the steps with Docker
+      - image: circleci/node:10-browsers # ...with this image as the primary container; this is where all `steps` will run
+    steps: # a collection of executable commands
+      - checkout
+      - run:
+          name: install-npm-wee
+          command: npm ci
       - run: # run tests
           name: test
-          command: npm test
+          command: npm ci:ngnext
 workflows:
   version: 2
   test:
     jobs:
       - lint
-      - test
+      - nglatest
       - ng80
+      - ngnext

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:interoperability": "ng e2e localforage",
     "test:ivy": "ng e2e ivy",
     "lint": "ng lint",
-    "publish": "npm run lint && npm test && npm run build && npm publish dist/ngx-pwa/local-storage --access public",
+    "publish": "npm run lint && npm run build && npm test && npm publish dist/ngx-pwa/local-storage --access public",
     "ci:nglatest": "npm run build && npm run test && npm run test:ivy",
     "ci:ngnext": "npm run build && @angular/common@next @angular/compiler@next @angular/core@next @angular/platform-browser@next @angular/platform-browser-dynamic@next @angular/router@next @angular/cli@next @angular/compiler-cli@next @angular-devkit/build-angular@next @angular-devkit/build-ng-packagr@next && npm run test && npm run test:ivy",
     "ci:ng80": "npm run build && npm install typescript@3.4.1 rxjs@6.4.0 zone.js@0.9.1 @angular/common@8.0.0 @angular/compiler@8.0.0 @angular/core@8.0.0 @angular/platform-browser@8.0.0 @angular/platform-browser-dynamic@8.0.0 @angular/router@8.0.0 @angular/cli@8.0.1 @angular/compiler-cli@8.0.0 @angular-devkit/build-angular@0.800.1 @angular-devkit/build-ng-packagr@0.800.1 && npm run test"

--- a/package.json
+++ b/package.json
@@ -6,15 +6,16 @@
     "start": "ng serve demo",
     "start:iframe": "ng serve iframe --port 8080",
     "build": "ng build ngx-pwa-local-storage --prod && copyfiles README.md LICENSE dist/ngx-pwa/local-storage",
-    "test": "npm run test:specs && npm run build && webdriver-manager update && npm run test:demo && npm run test:interoperability && npm run test:ivy:fix && npm run test:ivy",
+    "test": "npm run test:specs && webdriver-manager update && npm run test:demo && npm run test:interoperability",
     "test:specs": "ng test ngx-pwa-local-storage --watch false",
     "test:demo": "ng e2e demo",
     "test:interoperability": "ng e2e localforage",
     "test:ivy": "ng e2e ivy",
-    "test:ivy:fix": "./node_modules/.bin/ivy-ngcc -s ./dist",
     "lint": "ng lint",
     "publish": "npm run lint && npm test && npm run build && npm publish dist/ngx-pwa/local-storage --access public",
-    "ci:ng80": "npm install typescript@3.4.1 rxjs@6.4.0 zone.js@0.9.1 @angular/common@8.0.0 @angular/compiler@8.0.0 @angular/core@8.0.0 @angular/platform-browser@8.0.0 @angular/platform-browser-dynamic@8.0.0 @angular/router@8.0.0 @angular/cli@8.0.1 @angular/compiler-cli@8.0.0 @angular-devkit/build-angular@0.800.1 @angular-devkit/build-ng-packagr@0.800.1"
+    "ci:nglatest": "npm run build && npm run test && npm run test:ivy",
+    "ci:ngnext": "npm run build && @angular/common@next @angular/compiler@next @angular/core@next @angular/platform-browser@next @angular/platform-browser-dynamic@next @angular/router@next @angular/cli@next @angular/compiler-cli@next @angular-devkit/build-angular@next @angular-devkit/build-ng-packagr@next && npm run test && npm run test:ivy",
+    "ci:ng80": "npm run build && npm install typescript@3.4.1 rxjs@6.4.0 zone.js@0.9.1 @angular/common@8.0.0 @angular/compiler@8.0.0 @angular/core@8.0.0 @angular/platform-browser@8.0.0 @angular/platform-browser-dynamic@8.0.0 @angular/router@8.0.0 @angular/cli@8.0.1 @angular/compiler-cli@8.0.0 @angular-devkit/build-angular@0.800.1 @angular-devkit/build-ng-packagr@0.800.1 && npm run test"
   },
   "private": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
     "test:ivy": "ng e2e ivy",
     "lint": "ng lint",
     "publish": "npm run lint && npm run build && npm test && npm publish dist/ngx-pwa/local-storage --access public",
-    "ci:nglatest": "npm run build && npm run test && npm run test:ivy",
-    "ci:ngnext": "npm run build && npm install @angular/common@next @angular/compiler@next @angular/core@next @angular/platform-browser@next @angular/platform-browser-dynamic@next @angular/router@next @angular/cli@next @angular/compiler-cli@next @angular-devkit/build-angular@next @angular-devkit/build-ng-packagr@next && npm run test && npm run test:ivy",
-    "ci:ng80": "npm run build && npm install typescript@3.4.1 rxjs@6.4.0 zone.js@0.9.1 @angular/common@8.0.0 @angular/compiler@8.0.0 @angular/core@8.0.0 @angular/platform-browser@8.0.0 @angular/platform-browser-dynamic@8.0.0 @angular/router@8.0.0 @angular/cli@8.0.1 @angular/compiler-cli@8.0.0 @angular-devkit/build-angular@0.800.1 @angular-devkit/build-ng-packagr@0.800.1 && npm run test"
+    "ci:nglatest": "npm ci && npm run build && npm run test && npm run test:ivy",
+    "ci:ngnext": "npm ci && npm run build && npm install @angular/common@next @angular/compiler@next @angular/core@next @angular/platform-browser@next @angular/platform-browser-dynamic@next @angular/router@next @angular/cli@next @angular/compiler-cli@next @angular-devkit/build-angular@next @angular-devkit/build-ng-packagr@next && npm run test && npm run test:ivy",
+    "ci:ng80": "npm ci && npm run build && npm install typescript@3.4.1 rxjs@6.4.0 zone.js@0.9.1 @angular/common@8.0.0 @angular/compiler@8.0.0 @angular/core@8.0.0 @angular/platform-browser@8.0.0 @angular/platform-browser-dynamic@8.0.0 @angular/router@8.0.0 @angular/cli@8.0.1 @angular/compiler-cli@8.0.0 @angular-devkit/build-angular@0.800.1 @angular-devkit/build-ng-packagr@0.800.1 && npm run test"
   },
   "private": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint": "ng lint",
     "publish": "npm run lint && npm run build && npm test && npm publish dist/ngx-pwa/local-storage --access public",
     "ci:nglatest": "npm run build && npm run test && npm run test:ivy",
-    "ci:ngnext": "npm run build && @angular/common@next @angular/compiler@next @angular/core@next @angular/platform-browser@next @angular/platform-browser-dynamic@next @angular/router@next @angular/cli@next @angular/compiler-cli@next @angular-devkit/build-angular@next @angular-devkit/build-ng-packagr@next && npm run test && npm run test:ivy",
+    "ci:ngnext": "npm run build && npm install @angular/common@next @angular/compiler@next @angular/core@next @angular/platform-browser@next @angular/platform-browser-dynamic@next @angular/router@next @angular/cli@next @angular/compiler-cli@next @angular-devkit/build-angular@next @angular-devkit/build-ng-packagr@next && npm run test && npm run test:ivy",
     "ci:ng80": "npm run build && npm install typescript@3.4.1 rxjs@6.4.0 zone.js@0.9.1 @angular/common@8.0.0 @angular/compiler@8.0.0 @angular/core@8.0.0 @angular/platform-browser@8.0.0 @angular/platform-browser-dynamic@8.0.0 @angular/router@8.0.0 @angular/cli@8.0.1 @angular/compiler-cli@8.0.0 @angular-devkit/build-angular@0.800.1 @angular-devkit/build-ng-packagr@0.800.1 && npm run test"
   },
   "private": true,


### PR DESCRIPTION
This PR:
- add a test with Angular `next` version
- test Ivy only on latest and next (as for now it's in beta, so initial Angular Ivy in v8.0.0 was not stable), which allows to remove an old Ivy build fix
- move from CI caching `node_modules` to `npm ci`
- for all tests, build first with latest, as it's the published version