### PR TITLE
feat: removed deprecated features

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,8 +1,9 @@
 # Migration guides
 
 - [Migration from the old `angular-async-local-storage` package to `@ngx-pwa/local-storage`](./docs/MIGRATION_TO_NEW_PACKAGE.md)
-- [Migration to version 6](./docs/MIGRATION_TO_V6.md)
+- [Migration to version 6](./docs/MIGRATION_TO_V6.md) (for Angular 6 & 7)
 - [Migration to version 8](./docs/MIGRATION_TO_V8.md)
+- [Migration to version 9](./docs/MIGRATION_TO_V9.md)
 
 [Full changelog available here.](./CHANGELOG.md)
 

--- a/docs/MIGRATION_TO_V9.md
+++ b/docs/MIGRATION_TO_V9.md
@@ -1,0 +1,21 @@
+# Migration guide to version 9
+
+## Removed deprecated features
+
+The following APIs were already deprecated in v8 and are now removed in v9.
+Please follow the [migration guide to v8](./MIGRATION_TO_V8.md) for more details about how to update to new APIs.
+
+- Removed providers for prefix management
+  - **If you're concerned, be very careful with this migration, otherwise you could lost previously stored data**
+  - `{ provide: LOCAL_STORAGE_PREFIX, useValue: 'myapp' }` and `localStorageProviders()` (use `StorageModule.forRoot({ LSPrefix: 'myapp_', IDBDBName: 'myapp_ngStorage' })` module import instead)
+  - `LocalStorageProvidersConfig` interface (useless)
+- Removed APIs in validation
+  - `JSONSchemaNumeric` interface (use `JSONSchema` instead)
+  - `LSGetItemOptions` interface (useless)
+- Removed methods in `LocalStorage` service
+  - `.size` (use `.length` or `StorageMap.size` instead)
+  - `.has()` (use `StorageMap.has()` instead)
+  - `.keys()` (use *iterative* `StorageMap.keys()` instead)
+  - `.setItemSubscribe()` (use `.setItem().subscribe()` instead)
+  - `.removeItemSubscribe()` (use `.removeItem().subscribe()` instead)
+  - `.clearSubscribe()` (use `.clear().subscribe()` instead)

--- a/projects/ngx-pwa/local-storage/src/lib/databases/indexeddb-database.ts
+++ b/projects/ngx-pwa/local-storage/src/lib/databases/indexeddb-database.ts
@@ -5,7 +5,7 @@ import { map, mergeMap, first, takeWhile, tap, mapTo } from 'rxjs/operators';
 import { LocalDatabase } from './local-database';
 import { IDBBrokenError } from './exceptions';
 import {
-  IDB_DB_NAME, IDB_STORE_NAME, DEFAULT_IDB_STORE_NAME, IDB_DB_VERSION, LOCAL_STORAGE_PREFIX,
+  IDB_DB_NAME, IDB_STORE_NAME, DEFAULT_IDB_STORE_NAME, IDB_DB_VERSION,
   DEFAULT_IDB_DB_NAME, DEFAULT_IDB_DB_VERSION, IDB_NO_WRAP, DEFAULT_IDB_NO_WRAP
 } from '../tokens';
 
@@ -51,20 +51,15 @@ export class IndexedDBDatabase implements LocalDatabase {
    * @param storeName `indexedDB` store name
    * @param dbVersion `indexedDB` database version
    * @param noWrap `indexedDB` database version
-   * @param oldPrefix Pre-v8 backward compatible prefix
    */
   constructor(
     @Inject(IDB_DB_NAME) dbName = DEFAULT_IDB_DB_NAME,
     @Inject(IDB_STORE_NAME) storeName = DEFAULT_IDB_STORE_NAME,
     @Inject(IDB_DB_VERSION) dbVersion = DEFAULT_IDB_DB_VERSION,
     @Inject(IDB_NO_WRAP) noWrap = DEFAULT_IDB_NO_WRAP,
-    // tslint:disable-next-line: deprecation
-    @Inject(LOCAL_STORAGE_PREFIX) oldPrefix = '',
   ) {
 
-    /* Initialize `indexedDB` database name, with prefix if provided by the user */
-    this.dbName = oldPrefix ? `${oldPrefix}_${dbName}` : dbName;
-
+    this.dbName = dbName;
     this.storeName = storeName;
     this.dbVersion = dbVersion;
     this.noWrap = noWrap;

--- a/projects/ngx-pwa/local-storage/src/lib/databases/local-database.ts
+++ b/projects/ngx-pwa/local-storage/src/lib/databases/local-database.ts
@@ -5,7 +5,7 @@ import { Observable } from 'rxjs';
 import { IndexedDBDatabase } from './indexeddb-database';
 import { LocalStorageDatabase } from './localstorage-database';
 import { MemoryDatabase } from './memory-database';
-import { IDB_STORE_NAME, IDB_DB_NAME, LOCAL_STORAGE_PREFIX, LS_PREFIX, IDB_DB_VERSION, IDB_NO_WRAP } from '../tokens';
+import { IDB_STORE_NAME, IDB_DB_NAME, LS_PREFIX, IDB_DB_VERSION, IDB_NO_WRAP } from '../tokens';
 
 /**
  * Factory to create a storage according to browser support
@@ -13,12 +13,11 @@ import { IDB_STORE_NAME, IDB_DB_NAME, LOCAL_STORAGE_PREFIX, LS_PREFIX, IDB_DB_VE
  * @param LSPrefix Prefix for `localStorage` keys to avoid collision for multiple apps on the same subdomain
  * @param IDBDBName `indexedDB` database name
  * @param IDBstoreName `indexedDB` storeName name
- * @param oldPrefix Prefix option prior to v8 to avoid collision for multiple apps on the same subdomain
  * @see {@link https://github.com/cyrilletuzi/angular-async-local-storage/blob/master/docs/BROWSERS_SUPPORT.md}
  */
 export function localDatabaseFactory(
   platformId: string, LSPrefix: string, IDBDBName: string, IDBStoreName: string,
-  IDBDBVersion: number, IDBNoWrap: boolean, oldPrefix: string): LocalDatabase {
+  IDBDBVersion: number, IDBNoWrap: boolean): LocalDatabase {
 
   /* When storage is fully disabled in browser (via the "Block all cookies" option),
    * just trying to check `indexedDB` or `localStorage` variables causes a security exception.
@@ -37,7 +36,7 @@ export function localDatabaseFactory(
       * Will be the case for:
       * - IE10+ and all other browsers in normal mode
       * - Chromium / Safari private mode, but in this case, data will be swiped when the user leaves the app */
-      return new IndexedDBDatabase(IDBDBName, IDBStoreName, IDBDBVersion, IDBNoWrap, oldPrefix);
+      return new IndexedDBDatabase(IDBDBName, IDBStoreName, IDBDBVersion, IDBNoWrap);
 
     } else if (isPlatformBrowser(platformId)
     && (localStorage !== undefined) && (localStorage !== null) && ('getItem' in localStorage)) {
@@ -54,7 +53,7 @@ export function localDatabaseFactory(
       * For Firefox, can only be detected later in `IndexedDBDatabase.connect()`
       * @see {@link https://bugzilla.mozilla.org/show_bug.cgi?id=781982}
       */
-      return new LocalStorageDatabase(LSPrefix, oldPrefix);
+      return new LocalStorageDatabase(LSPrefix);
 
     }
 
@@ -79,8 +78,6 @@ export function localDatabaseFactory(
     IDB_STORE_NAME,
     IDB_DB_VERSION,
     IDB_NO_WRAP,
-    // tslint:disable-next-line: deprecation
-    LOCAL_STORAGE_PREFIX,
   ]
 })
 export abstract class LocalDatabase {

--- a/projects/ngx-pwa/local-storage/src/lib/databases/localstorage-database.ts
+++ b/projects/ngx-pwa/local-storage/src/lib/databases/localstorage-database.ts
@@ -4,7 +4,7 @@ import { observeOn } from 'rxjs/operators';
 
 import { LocalDatabase } from './local-database';
 import { SerializationError } from './exceptions';
-import { LOCAL_STORAGE_PREFIX, LS_PREFIX } from '../tokens';
+import { LS_PREFIX } from '../tokens';
 
 @Injectable({
   providedIn: 'root'
@@ -19,16 +19,13 @@ export class LocalStorageDatabase implements LocalDatabase {
   /**
    * Constructor params are provided by Angular (but can also be passed manually in tests)
    * @param prefix Prefix option to avoid collision for multiple apps on the same subdomain or for interoperability
-   * @param oldPrefix Prefix option prior to v8 to avoid collision for multiple apps on the same subdomain or for interoperability
    */
   constructor(
     @Inject(LS_PREFIX) prefix = '',
-    // tslint:disable-next-line: deprecation
-    @Inject(LOCAL_STORAGE_PREFIX) oldPrefix = '',
   ) {
 
-    /* Priority for the new prefix option, otherwise old prefix with separator, or no prefix */
-    this.prefix = prefix || (oldPrefix ? `${oldPrefix}_` : '');
+    /* Prefix if asked, or no prefix otherwise */
+    this.prefix = prefix || '';
 
   }
 

--- a/projects/ngx-pwa/local-storage/src/lib/storages/index.ts
+++ b/projects/ngx-pwa/local-storage/src/lib/storages/index.ts
@@ -1,3 +1,3 @@
 export { StorageMap } from './storage-map.service';
-export { LSGetItemOptions, LocalStorage } from './local-storage.service';
+export { LocalStorage } from './local-storage.service';
 export { VALIDATION_ERROR, ValidationError } from './exceptions';

--- a/projects/ngx-pwa/local-storage/src/lib/storages/local-storage.service.spec.ts
+++ b/projects/ngx-pwa/local-storage/src/lib/storages/local-storage.service.spec.ts
@@ -1,5 +1,4 @@
-import { from } from 'rxjs';
-import { mergeMap, filter, tap } from 'rxjs/operators';
+import { mergeMap, tap } from 'rxjs/operators';
 
 import { LocalStorage } from './local-storage.service';
 import { StorageMap } from './storage-map.service';
@@ -318,97 +317,6 @@ function tests(description: string, localStorageServiceFactory: () => LocalStora
 
       });
 
-      it('keys()', (done) => {
-
-        const key1 = 'index1';
-        const key2 = 'index2';
-
-        localStorageService.setItem(key1, 'test').pipe(
-          mergeMap(() => localStorageService.setItem(key2, 'test')),
-          // tslint:disable-next-line: deprecation
-          mergeMap(() => localStorageService.keys()),
-        ).subscribe((keys) => {
-
-          /* Sorting because keys order is not standard in `localStorage` (in Firefox especially) */
-          expect([key1, key2].sort()).toEqual(keys.sort());
-
-          done();
-
-        });
-
-      });
-
-      it('getKey() when no items', (done) => {
-
-        // tslint:disable-next-line: deprecation
-        localStorageService.keys().subscribe((keys) => {
-
-          expect(keys.length).toBe(0);
-
-          done();
-
-        });
-
-      });
-
-      it('key() on existing', (done) => {
-
-        localStorageService.setItem(key, 'test').pipe(
-          // tslint:disable-next-line: deprecation
-          mergeMap(() => localStorageService.has(key))
-        ).subscribe((result) => {
-
-          expect(result).toBe(true);
-
-          done();
-
-        });
-
-      });
-
-      it('key() on unexisting', (done) => {
-
-        // tslint:disable-next-line: deprecation
-        localStorageService.has(`nokey${Date.now()}`).subscribe((result) => {
-
-          expect(result).toBe(false);
-
-          done();
-
-        });
-
-      });
-
-      it('advanced case: remove only some items', (done) => {
-
-        localStorageService.setItem('user_firstname', 'test').pipe(
-          mergeMap(() => localStorageService.setItem('user_lastname', 'test')),
-          mergeMap(() => localStorageService.setItem('app_data1', 'test')),
-          mergeMap(() => localStorageService.setItem('app_data2', 'test')),
-          // tslint:disable-next-line: deprecation
-          mergeMap(() => localStorageService.keys()),
-          /* Now we will have an `Observable` emiting multiple values */
-          mergeMap((keys) => from(keys)),
-          filter((currentKey) => currentKey.startsWith('app_')),
-          mergeMap((currentKey) => localStorageService.removeItem(currentKey)),
-        ).subscribe({
-          /* So we need to wait for completion of all actions to check */
-          complete: () => {
-
-
-          localStorageService.length.subscribe((size) => {
-
-            expect(size).toBe(2);
-
-            done();
-
-          });
-
-          }
-        });
-
-      });
-
     });
 
     describe('JSON schema', () => {
@@ -580,36 +488,6 @@ function tests(description: string, localStorageServiceFactory: () => LocalStora
       it('length', (done) => {
 
         localStorageService.length.subscribe({
-          complete: () => {
-
-            expect().nothing();
-
-            done();
-
-          }
-        });
-
-      });
-
-      it('keys()', (done) => {
-
-        // tslint:disable-next-line: deprecation
-        localStorageService.keys().subscribe({
-          complete: () => {
-
-            expect().nothing();
-
-            done();
-
-          }
-        });
-
-      });
-
-      it('has()', (done) => {
-
-        // tslint:disable-next-line: deprecation
-        localStorageService.has(key).subscribe({
           complete: () => {
 
             expect().nothing();

--- a/projects/ngx-pwa/local-storage/src/lib/storages/local-storage.service.ts
+++ b/projects/ngx-pwa/local-storage/src/lib/storages/local-storage.service.ts
@@ -1,38 +1,14 @@
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
-import { mapTo, toArray, map } from 'rxjs/operators';
+import { mapTo, map } from 'rxjs/operators';
 
 import { StorageMap } from './storage-map.service';
 import { JSONSchema, JSONSchemaBoolean, JSONSchemaInteger, JSONSchemaNumber, JSONSchemaString, JSONSchemaArrayOf } from '../validation';
-
-/**
- * @deprecated Will be removed in v9
- */
-export interface LSGetItemOptions {
-
-  /**
-   * Subset of the JSON Schema standard.
-   * Types are enforced to validate everything: each value **must** have a `type`.
-   * @see {@link https://github.com/cyrilletuzi/angular-async-local-storage/blob/master/docs/VALIDATION.md}
-   */
-  schema?: JSONSchema | null;
-
-}
 
 @Injectable({
   providedIn: 'root'
 })
 export class LocalStorage {
-
-  /**
-   * Number of items in storage
-   * @deprecated Use `.length`, or use `.size` via the new `StorageMap` service. Will be removed in v9.
-   */
-  get size(): Observable<number> {
-
-    return this.length;
-
-  }
 
   /**
    * Number of items in storage wrapped in an `Observable`
@@ -59,7 +35,7 @@ export class LocalStorage {
    * @param schema Optional JSON schema to validate the data.
    * **Note you must pass the schema directly as the second argument.**
    * **Passing the schema in an object `{ schema }` is deprecated and only here**
-   * **for backward compatibility: it will be removed in v9.**
+   * **for backward compatibility: it will be removed in a future version.**
    * @returns The item's value if the key exists, `null` otherwise, wrapped in a RxJS `Observable`
    *
    * @example
@@ -169,84 +145,6 @@ export class LocalStorage {
       /* Transform `undefined` into `true` for backward compatibility with v7 */
       mapTo(true),
     );
-
-  }
-
-  /**
-   * Get all keys stored in storage
-   * @returns A list of the keys wrapped in a RxJS `Observable`
-   * @deprecated Moved to `StorageMap` service. Will be removed in v9.
-   * Note that while this method was giving you all keys at once in an array,
-   * the new `keys()` method in `StorageMap` service will *iterate* on each key.
-   */
-  keys(): Observable<string[]> {
-
-    return this.storageMap.keys().pipe(
-      /* Backward compatibility with v7: transform iterating `Observable` to a single array value */
-      toArray(),
-    );
-
-  }
-
-  /**
-   * Tells if a key exists in storage
-   * @returns A RxJS `Observable` telling if the key exists
-   * @deprecated Moved to `StorageMap` service. Will be removed in v9.
-   */
-  has(key: string): Observable<boolean> {
-
-    return this.storageMap.has(key);
-
-  }
-
-  /**
-   * Set an item in storage, and auto-subscribe
-   * @param key The item's key
-   * @param data The item's value
-   * **WARNING: should be avoided in most cases, use this method only if these conditions are fulfilled:**
-   * - you don't need to manage the error callback (errors will silently fail),
-   * - you don't need to wait the operation to finish before the next one (remember, it's asynchronous).
-   * @deprecated Promoted bad practices. Will be removed in v9.
-   */
-  setItemSubscribe(key: string, data: string | number | boolean | object): void {
-
-    this.setItem(key, data).subscribe({
-      next: () => {},
-      error: () => {},
-    });
-
-  }
-
-  /**
-   * Delete an item in storage, and auto-subscribe
-   * @param key The item's key
-   * **WARNING: should be avoided in most cases, use this method only if these conditions are fulfilled:**
-   * - you don't need to manage the error callback (errors will silently fail),
-   * - you don't need to wait the operation to finish before the next one (remember, it's asynchronous).
-   * @deprecated Promoted bad practices. Will be removed in v9.
-   */
-   removeItemSubscribe(key: string): void {
-
-    this.removeItem(key).subscribe({
-      next: () => {},
-      error: () => {},
-    });
-
-  }
-
-  /**
-   * Delete all items in storage, and auto-subscribe
-   * **WARNING: should be avoided in most cases, use this method only if these conditions are fulfilled:**
-   * - you don't need to manage the error callback (errors will silently fail),
-   * - you don't need to wait the operation to finish before the next one (remember, it's asynchronous).
-   * @deprecated Promoted bad practices. Will be removed in v9.
-   */
-  clearSubscribe(): void {
-
-    this.clear().subscribe({
-      next: () => {},
-      error: () => {},
-    });
 
   }
 

--- a/projects/ngx-pwa/local-storage/src/lib/storages/storage-map.service.spec.ts
+++ b/projects/ngx-pwa/local-storage/src/lib/storages/storage-map.service.spec.ts
@@ -651,16 +651,11 @@ describe('StorageMap', () => {
 
   tests('localStorage with prefix', () => new StorageMap(new LocalStorageDatabase(`ls`)));
 
-  tests('localStorage with old prefix', () => new StorageMap(new LocalStorageDatabase(undefined, `old`)));
-
   tests('indexedDB', () => new StorageMap(new IndexedDBDatabase()));
 
   tests('indexedDB with no wrap', () => new StorageMap(new IndexedDBDatabase()));
 
   tests('indexedDB with custom options', () => new StorageMap(new IndexedDBDatabase('customDbTest', 'storeTest', 2)));
-
-  tests('indexedDB with old prefix', () =>
-    new StorageMap(new IndexedDBDatabase(undefined, undefined, undefined, undefined, `myapp${Date.now()}`)));
 
   tests(
     'indexedDB with custom database and store names',
@@ -848,32 +843,6 @@ describe('StorageMap', () => {
 
     });
 
-    it('indexedDB old prefix (will be pending in Firefox private mode)', (done) => {
-
-      /* Unique name to be sure `indexedDB` `upgradeneeded` event is triggered */
-      const prefix = `myapp${Date.now()}`;
-      const localStorageService = new StorageMap(new IndexedDBDatabase(undefined, undefined, undefined, undefined, prefix));
-
-      /* Do a request first to allow localStorage fallback if needed */
-      localStorageService.get('test').subscribe(() => {
-
-        if (localStorageService.backingEngine === 'indexedDB') {
-
-          expect(localStorageService.backingStore.database).toBe(`${prefix}_${DEFAULT_IDB_DB_NAME}`);
-
-          closeAndDeleteDatabase(done, localStorageService);
-
-        } else {
-
-          /* Cases: Firefox private mode */
-          pending();
-
-        }
-
-      });
-
-    });
-
     it('localStorage prefix', () => {
 
       const prefix = `ls_`;
@@ -882,17 +851,6 @@ describe('StorageMap', () => {
 
       // tslint:disable-next-line: no-string-literal
       expect(localStorageService.fallbackBackingStore.prefix).toBe(prefix);
-
-    });
-
-    it('localStorage old prefix', () => {
-
-      const prefix = `old`;
-
-      const localStorageService = new StorageMap(new LocalStorageDatabase(undefined, prefix));
-
-      // tslint:disable-next-line: no-string-literal
-      expect(localStorageService.fallbackBackingStore.prefix).toBe(`${prefix}_`);
 
     });
 

--- a/projects/ngx-pwa/local-storage/src/lib/storages/storage-map.service.ts
+++ b/projects/ngx-pwa/local-storage/src/lib/storages/storage-map.service.ts
@@ -8,7 +8,7 @@ import {
   JSONSchemaNumber, JSONSchemaString, JSONSchemaArrayOf, JSONValidator
 } from '../validation';
 import { LocalDatabase, IDB_BROKEN_ERROR, LocalStorageDatabase, IndexedDBDatabase, MemoryDatabase } from '../databases';
-import { LS_PREFIX, LOCAL_STORAGE_PREFIX } from '../tokens';
+import { LS_PREFIX } from '../tokens';
 
 @Injectable({
   providedIn: 'root'
@@ -20,14 +20,11 @@ export class StorageMap {
    * @param database Storage to use
    * @param jsonValidator Validator service
    * @param LSPrefix Prefix for `localStorage` keys to avoid collision for multiple apps on the same subdomain or for interoperability
-   * @param oldPrefix Prefix option prior to v8 to avoid collision for multiple apps on the same subdomain or for interoperability
    */
   constructor(
     protected database: LocalDatabase,
     protected jsonValidator: JSONValidator = new JSONValidator(),
     @Inject(LS_PREFIX) protected LSPrefix = '',
-    // tslint:disable-next-line: deprecation
-    @Inject(LOCAL_STORAGE_PREFIX) protected oldPrefix = '',
   ) {}
 
   /**
@@ -316,7 +313,7 @@ export class StorageMap {
           if ('getItem' in localStorage) {
 
             /* Fallback to `localStorage` if available */
-            this.database = new LocalStorageDatabase(this.LSPrefix, this.oldPrefix);
+            this.database = new LocalStorageDatabase(this.LSPrefix);
 
           } else {
 

--- a/projects/ngx-pwa/local-storage/src/lib/tokens.ts
+++ b/projects/ngx-pwa/local-storage/src/lib/tokens.ts
@@ -1,45 +1,4 @@
-import { InjectionToken, Provider } from '@angular/core';
-
-/**
- * Token to provide a prefix to avoid collision when multiple apps on the same *sub*domain.
- * @deprecated **Will be removed in v9**. Set options with `StorageModule.forRoot()` instead:
- *
- * Before v8:
- * ```ts
- * import { localStorageProviders, LOCAL_STORAGE_PREFIX } from '@ngx-pwa/local-storage';
- *
- * @NgModule({
- *   providers: [
- *     { provide: LOCAL_STORAGE_PREFIX, useValue: 'myapp' },
- *   ]
- * })
- * export class AppModule {}
- * ```
- *
- * Since v8:
- * ```ts
- * import { StorageModule } from '@ngx-pwa/local-storage';
- *
- * @NgModule({
- *   imports: [
- *     StorageModule.forRoot({
- *       LSPrefix: 'myapp_', // Note the underscore
- *       IDBDBName: 'myapp_ngStorage',
- *     }),
- *   ]
- * })
- * export class AppModule {}
- * ```
- *
- * **Be very careful while changing this in applications already deployed in production,**
- * **as an error would mean the loss of all previously stored data.**
- * **SO PLEASE TEST BEFORE PUSHING IN PRODUCTION.**
- *
- */
-export const LOCAL_STORAGE_PREFIX = new InjectionToken<string>('localStoragePrefix', {
-  providedIn: 'root',
-  factory: () => ''
-});
+import { InjectionToken } from '@angular/core';
 
 /**
  * Token to provide a prefix to `localStorage` keys.
@@ -93,9 +52,7 @@ export const IDB_STORE_NAME = new InjectionToken<string>('localStorageIDBStoreNa
 /**
  * Default value for interoperability with native `indexedDB` and other storage libs,
  * by changing how values are stored in `indexedDB` database.
- * Currently defaults to `false` for backward compatiblity in existing applications
- * (**DO NOT CHANGE IT IN PRODUCTION**, as it would break with existing data),
- * but **should be `false` in all new applications, as it may become the default in a future version**.
+ * Currently defaults to `false` for backward compatiblity in existing applications.
  */
 export const DEFAULT_IDB_NO_WRAP = false;
 
@@ -151,67 +108,5 @@ export interface StorageConfig {
    * but **should be `true` in all new applications, as it may become the default in a future version**.
    */
   IDBNoWrap?: boolean;
-
-}
-
-/**
- * @deprecated in favor of `StorageConfig`. Will be removed in v9.
- */
-export interface LocalStorageProvidersConfig {
-
-  /**
-   * Prefix to avoid collision when there are *multiple apps on the same subdomain*.
-   * **WARNING: do not change this option in an app already deployed in production, as previously stored data would be lost.**
-   * @deprecated Use `LSPrefix` and `IDBDBName` options instead. Will be removed in v9.
-   */
-  prefix?: string;
-
-}
-
-/**
- * Helper function to provide options. **Must be used at initialization, ie. in `AppModule`.**
- * @param config Options.
- * @returns A list of providers for the lib options.
- * @deprecated **Will be removed in v9.** Set options via `StorageModule.forRoot()` instead:
- *
- * Before v8:
- * ```ts
- * import { localStorageProviders, LOCAL_STORAGE_PREFIX } from '@ngx-pwa/local-storage';
- *
- * @NgModule({
- *   providers: [
- *     localStorageProviders({ prefix: 'myapp' }),
- *   ]
- * })
- * export class AppModule {}
- * ```
- *
- * Since v8:
- * ```ts
- * import { StorageModule } from '@ngx-pwa/local-storage';
- *
- * @NgModule({
- *   imports: [
- *     StorageModule.forRoot({
- *       LSPrefix: 'myapp_', // Note the underscore
- *       IDBDBName: 'myapp_ngStorage',
- *     }),
- *   ]
- * })
- * export class AppModule {}
- * ```
- *
- * **Be very careful while changing this in applications already deployed in production,**
- * **as an error would mean the loss of all previously stored data.**
- * **SO PLEASE TEST BEFORE PUSHING IN PRODUCTION.**
- *
- */
-// tslint:disable-next-line: deprecation
-export function localStorageProviders(config: LocalStorageProvidersConfig): Provider[] {
-
-  return [
-    // tslint:disable-next-line: deprecation
-    config.prefix ? { provide: LOCAL_STORAGE_PREFIX, useValue: config.prefix } : [],
-  ];
 
 }

--- a/projects/ngx-pwa/local-storage/src/lib/validation/index.ts
+++ b/projects/ngx-pwa/local-storage/src/lib/validation/index.ts
@@ -1,5 +1,5 @@
 export {
   JSONSchema, JSONSchemaObject, JSONSchemaArray, JSONSchemaArrayOf,
-  JSONSchemaBoolean, JSONSchemaInteger, JSONSchemaNumber, JSONSchemaNumeric, JSONSchemaString
+  JSONSchemaBoolean, JSONSchemaInteger, JSONSchemaNumber, JSONSchemaString
 } from './json-schema';
 export { JSONValidator } from './json-validator';

--- a/projects/ngx-pwa/local-storage/src/lib/validation/json-schema.ts
+++ b/projects/ngx-pwa/local-storage/src/lib/validation/json-schema.ts
@@ -253,13 +253,6 @@ export interface JSONSchemaObject {
 }
 
 /**
- * @deprecated Deprecated in favor of `JSONSchemaNumber` or `JSONSchemaInteger`
- * Available for backward-compatibility only, **do not use**.
- * May be removed in v9.
- */
-export type JSONSchemaNumeric = JSONSchemaNumber | JSONSchemaInteger;
-
-/**
  * Subset of the JSON Schema standard.
  * Types are enforced to validate everything: each value **must** have a `type`.
  * @see {@link https://github.com/cyrilletuzi/angular-async-local-storage/blob/master/docs/VALIDATION.md}

--- a/projects/ngx-pwa/local-storage/src/public_api.ts
+++ b/projects/ngx-pwa/local-storage/src/public_api.ts
@@ -5,11 +5,11 @@
 // TODO: Test with Bazel
 
 export {
-  JSONSchema, JSONSchemaBoolean, JSONSchemaInteger, JSONSchemaNumber,
-  JSONSchemaNumeric, JSONSchemaString, JSONSchemaArray, JSONSchemaArrayOf, JSONSchemaObject
+  JSONSchema, JSONSchemaBoolean, JSONSchemaInteger, JSONSchemaNumber, JSONSchemaString,
+  JSONSchemaArray, JSONSchemaArrayOf, JSONSchemaObject
 } from './lib/validation';
 export { LocalDatabase, SERIALIZATION_ERROR, SerializationError } from './lib/databases';
-export { LocalStorage, StorageMap, LSGetItemOptions, ValidationError, VALIDATION_ERROR } from './lib/storages';
+export { LocalStorage, StorageMap, ValidationError, VALIDATION_ERROR } from './lib/storages';
 export { JSONValidator } from './lib/validation';
-export { StorageConfig, localStorageProviders, LocalStorageProvidersConfig, LOCAL_STORAGE_PREFIX } from './lib/tokens';
+export { StorageConfig } from './lib/tokens';
 export { StorageModule } from './lib/storage.module';


### PR DESCRIPTION
The following APIs were already deprecated in v8 and are now removed in v9.

- Removed providers for prefix management
  - **If you're concerned, be very careful with this migration, otherwise you could lost previously stored data**
  - `{ provide: LOCAL_STORAGE_PREFIX, useValue: 'myapp' }` and `localStorageProviders()` (use `StorageModule.forRoot({ LSPrefix: 'myapp_', IDBDBName: 'myapp_ngStorage' })` module import instead)
  - `LocalStorageProvidersConfig` interface (useless)
- Removed APIs in validation
  - `JSONSchemaNumeric` interface (use `JSONSchema` instead)
  - `LSGetItemOptions` interface (useless)
- Removed methods in `LocalStorage` service
  - `.size` (use `.length` or `StorageMap.size` instead)
  - `.has()` (use `StorageMap.has()` instead)
  - `.keys()` (use *iterative* `StorageMap.keys()` instead)
  - `.setItemSubscribe()` (use `.setItem().subscribe()` instead)
  - `.removeItemSubscribe()` (use `.removeItem().subscribe()` instead)
  - `.clearSubscribe()` (use `.clear().subscribe()` instead)