### PR TITLE
build: align to ng-packagr 5.5.1 where tsickle is useless

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12625,31 +12625,6 @@
         "yn": "^3.0.0"
       }
     },
-    "tsickle": {
-      "version": "0.37.0",
-      "resolved": "https://registry.npmjs.org/tsickle/-/tsickle-0.37.0.tgz",
-      "integrity": "sha512-ufUZqLUNqh+kOfr52N/hJ5JbiDO32/CO7ZCteZBX9HA2kiejwEgDaJeJe1GAj2TIu683IgTA/LPKvlns6Liw0w==",
-      "dev": true,
-      "requires": {
-        "minimist": "^1.2.0",
-        "mkdirp": "^0.5.1",
-        "source-map": "^0.7.3"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.7.3",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
-          "dev": true
-        }
-      }
-    },
     "tslib": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "ng-packagr": "5.5.1",
     "protractor": "5.4.2",
     "ts-node": "8.4.1",
-    "tsickle": "0.37.0",
     "tslint": "5.20.0",
     "typescript": "3.5.3",
     "zone.js": "0.10.2"

--- a/projects/ngx-pwa/local-storage/tsconfig.lib.json
+++ b/projects/ngx-pwa/local-storage/tsconfig.lib.json
@@ -12,7 +12,6 @@
     ]
   },
   "angularCompilerOptions": {
-    "annotateForClosureCompiler": true,
     "skipTemplateCodegen": true,
     "strictMetadataEmit": true,
     "fullTemplateTypeCheck": true,


### PR DESCRIPTION
ng-packagr 5.5.1 is not relying on tsickle anymore, so this PR is removing this dep.

Also, `anotateForClosureCompiler` option (which triggerred tsickle) must be turned off accordingly.