### PR TITLE
fix: correctly propagate errors in idb requests

### DIFF
--- a/docs/ERRORS.md
+++ b/docs/ERRORS.md
@@ -19,7 +19,9 @@ this.storage.get('color').pipe(
 ```
 
 Could happen to anyone:
-- `.set()`: storage is full (`DOMException` with name `'QuotaExceededError`)
+- `.set()`: storage is full (`DOMException` with name `QuotaExceededError`)
+- `.set()`: value is too big (`DOMException` with name `UnknownError`),
+for example Chromium-based browsers have a 133169152 bytes limit
 
 Could only happen when in `localStorage` fallback:
 - `.set()`: error in JSON serialization because of circular references (`TypeError`)

--- a/projects/ngx-pwa/local-storage/src/lib/databases/indexeddb-database.ts
+++ b/projects/ngx-pwa/local-storage/src/lib/databases/indexeddb-database.ts
@@ -436,8 +436,10 @@ export class IndexedDBDatabase implements LocalDatabase {
   protected listenError(transactionOrRequest: IDBTransaction | IDBRequest): Observable<never> {
 
     return fromEvent(transactionOrRequest, 'error').pipe(
-      /* Throw on error to be able to catch errors in RxJS way */
-      mergeMap(() => throwError(transactionOrRequest.error)),
+      /* Throw on error to be able to catch errors in RxJS way.
+       * Here `event.target` must be used, as `transactionOrRequest.error` will be `null`
+       * if we are on the request and the error is only triggered later by the transaction */
+      mergeMap((event) => throwError((event.target as IDBTransaction | IDBRequest).error)),
     );
 
   }


### PR DESCRIPTION
This issue is quite tricky and seems like a browser bug.

When doing an `indexedDb` request, the error can happen on the request or on the transaction. But some requests (like a request with a value exceeding browsers size limit) may fail on a request level, while in fact the error is happening on the transaction. Thus, the error event is caught on the request, but getting `ibdrequest.error` is `null`.

Getting the error via `event.target.error` fixes the issue.

Fixes #395 