### PR TITLE
fix: typing corrections

### DIFF
--- a/projects/ngx-pwa/local-storage/src/lib/databases/memory-database.ts
+++ b/projects/ngx-pwa/local-storage/src/lib/databases/memory-database.ts
@@ -28,7 +28,7 @@ export class MemoryDatabase implements LocalDatabase {
    * @param key The item's key
    * @returns The item's value if the key exists, `undefined` otherwise, wrapped in a RxJS `Observable`
    */
-   get<T = unknown>(key: string): Observable<T | undefined> {
+  get<T = unknown>(key: string): Observable<T | undefined> {
 
     const rawData = this.memoryStorage.get(key) as T | undefined;
 
@@ -43,7 +43,7 @@ export class MemoryDatabase implements LocalDatabase {
    * @param data The item's value
    * @returns A RxJS `Observable` to wait the end of the operation
    */
-   set(key: string, data: unknown): Observable<undefined> {
+  set(key: string, data: unknown): Observable<undefined> {
 
     this.memoryStorage.set(key, data);
 
@@ -57,7 +57,7 @@ export class MemoryDatabase implements LocalDatabase {
    * @param key The item's key
    * @returns A RxJS `Observable` to wait the end of the operation
    */
-   delete(key: string): Observable<undefined> {
+  delete(key: string): Observable<undefined> {
 
     this.memoryStorage.delete(key);
 
@@ -70,7 +70,7 @@ export class MemoryDatabase implements LocalDatabase {
    * Deletes all items in memory
    * @returns A RxJS `Observable` to wait the end of the operation
    */
-   clear(): Observable<undefined> {
+  clear(): Observable<undefined> {
 
     this.memoryStorage.clear();
 

--- a/projects/ngx-pwa/local-storage/src/lib/storages/local-storage.service.ts
+++ b/projects/ngx-pwa/local-storage/src/lib/storages/local-storage.service.ts
@@ -74,8 +74,8 @@ export class LocalStorage {
   getItem<T = number[]>(key: string, schema: JSONSchemaArrayOf<JSONSchemaInteger | JSONSchemaNumber>): Observable<number[] | null>;
   getItem<T = boolean[]>(key: string, schema: JSONSchemaArrayOf<JSONSchemaBoolean>): Observable<boolean[] | null>;
   getItem<T = unknown>(key: string, schema: JSONSchema | { schema: JSONSchema }): Observable<T | null>;
-  getItem<T = unknown>(key: string, schema?: JSONSchema): Observable<unknown>;
-  getItem<T = unknown>(key: string, schema?: JSONSchema | { schema: JSONSchema } | undefined): Observable<unknown> {
+  getItem<T = unknown>(key: string, schema?: JSONSchema): Observable<T>;
+  getItem<T = unknown>(key: string, schema?: JSONSchema | { schema: JSONSchema } | undefined): Observable<T> {
 
     if (schema) {
 
@@ -84,14 +84,16 @@ export class LocalStorage {
 
       return this.storageMap.get<T>(key, schemaFinal).pipe(
         /* Transform `undefined` into `null` to align with `localStorage` API */
-        map((value) => (value !== undefined) ? value : null),
+        // tslint:disable-next-line: no-non-null-assertion
+        map((value) => (value !== undefined) ? value : null!),
       );
 
     } else {
 
       return this.storageMap.get(key).pipe(
         /* Transform `undefined` into `null` to align with `localStorage` API */
-        map((value) => (value !== undefined) ? value : null),
+        // tslint:disable-next-line: no-non-null-assertion
+        map((value) => (value !== undefined) ? value as T : null!),
       );
 
     }

--- a/projects/ngx-pwa/local-storage/src/lib/storages/storage-map.service.ts
+++ b/projects/ngx-pwa/local-storage/src/lib/storages/storage-map.service.ts
@@ -169,8 +169,8 @@ export class StorageMap {
   get<T = number[]>(key: string, schema: JSONSchemaArrayOf<JSONSchemaInteger | JSONSchemaNumber>): Observable<number[] | undefined>;
   get<T = boolean[]>(key: string, schema: JSONSchemaArrayOf<JSONSchemaBoolean>): Observable<boolean[] | undefined>;
   get<T = unknown>(key: string, schema: JSONSchema): Observable<T | undefined>;
-  get<T = unknown>(key: string, schema?: JSONSchema): Observable<unknown>;
-  get<T = unknown>(key: string, schema?: JSONSchema): Observable<unknown> {
+  get<T = unknown>(key: string, schema?: JSONSchema): Observable<T>;
+  get<T = unknown>(key: string, schema?: JSONSchema): Observable<T> {
 
     /* Get the data in storage */
     return this.database.get<T>(key).pipe(
@@ -181,7 +181,8 @@ export class StorageMap {
         /* No need to validate if the data is empty */
         if ((data === undefined) || (data === null)) {
 
-          return of(undefined);
+      // tslint:disable-next-line: no-non-null-assertion
+          return of(undefined!);
 
         } else if (schema) {
 
@@ -191,12 +192,12 @@ export class StorageMap {
           }
 
           /* Data have been checked, so it's OK to cast */
-          return of(data as T | undefined);
+          return of(data as T);
 
         }
 
         /* Cast to unknown as the data wasn't checked */
-        return of(data as unknown);
+        return of(data as T);
 
       }),
     );
@@ -330,8 +331,8 @@ export class StorageMap {
   watch<T = number[]>(key: string, schema: JSONSchemaArrayOf<JSONSchemaInteger | JSONSchemaNumber>): Observable<number[] | undefined>;
   watch<T = boolean[]>(key: string, schema: JSONSchemaArrayOf<JSONSchemaBoolean>): Observable<boolean[] | undefined>;
   watch<T = unknown>(key: string, schema: JSONSchema): Observable<T | undefined>;
-  watch<T = unknown>(key: string, schema?: JSONSchema): Observable<unknown>;
-  watch<T = unknown>(key: string, schema?: JSONSchema): Observable<unknown> {
+  watch<T = unknown>(key: string, schema?: JSONSchema): Observable<T>;
+  watch<T = unknown>(key: string, schema?: JSONSchema): Observable<T> {
 
     /* Check if there is already a notifier and cast according to schema */
     let notifier = this.notifiers.get(key) as ReplaySubject<typeof schema extends JSONSchema ? (T | undefined) : unknown>;
@@ -353,7 +354,7 @@ export class StorageMap {
     }
 
     /* Only the public API of the `Observable` should be returned */
-    return notifier.asObservable();
+    return notifier.asObservable() as Observable<T>;
 
   }
 


### PR DESCRIPTION
Currently the methods `get`, `getItem` and `watch`, ignore, in some overloads, the generic argument and returns Observable<unknown> in any situation.

**Current behavior**:
`watch<User>(user) // results in Observable<unknown>`

... so we have to do something like this:

`watch<User>(user)  as Observable<User>`

**The behavior with these fixes**:
`watch<User>(user) // results in Observable<User>`