### PR TITLE
feat: disallow wrong generics in get/watch()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,54 @@
 
 This lib is fully documented and so you'll find detailed [migration guides](./MIGRATION.md).
 
+## 11.0.0-1 (2020-10-19)
+
+**This is a pre-release version. Do NOT use in production.**
+
+### Feature
+
+Supports and **requires** Angular 11.
+
+### Typings
+
+TypeScript typings for `.get()` and `.watch()` has been modified to better match the library behavior.
+
+For now, wrong usages are just marked as deprecated, so there is **no breaking change**
+and it will just be reported by linters. But they may be removed in future releases.
+
+1. Cast without a JSON schema:
+```ts
+this.storage.get<User>('user');
+```
+was allowed but the result was still `unknown`.
+
+This is a very common misconception of client-side storage:
+you can store and get anything in storage, so many people think that casting as above
+is enough to get the right result type. It's not.
+
+Why? Because you're getting data from *client-side* storage:
+so it may have been modified (just go to your browser developer tools and hack what you want).
+
+A cast is just an information for *compilation*:
+it basically says to TypeScript: "believe me, it will be a `User`".
+But **that's not true: you're not sure you'll get a `User`**.
+
+This is why this library provides a *runtime* validation system,
+via a JSON schema as the second parameter.
+
+Be sure to read the [validation guide](https://github.com/cyrilletuzi/angular-async-local-storage/blob/master/docs/WATCHING.md) for all the why and how of validation.
+
+2. Mismatch between cast and simple JSON schema:
+```ts
+this.storage.get<number>('name', { type: 'string' });
+```
+was allowed but is of course an error. Now the match between the cast and simple JSON schemas (string, number, boolean and array of these) is checked.
+
+Note that in this scenario, the cast is not needed at all, it will be automatically inferred by the lib, so just do:
+```ts
+this.storage.get('name', { type: 'string' });
+```
+
 ## 10.1.0 (2020-09-03)
 
 No code change, just rebuilt with Angular 10.1.

--- a/docs/MIGRATION_TO_V11.md
+++ b/docs/MIGRATION_TO_V11.md
@@ -22,6 +22,48 @@ ng update @ngx-pwa/local-storage
 
 Done!
 
+## Changes
+
+### Typings
+
+TypeScript typings for `.get()` and `.watch()` has been modified to better match the library behavior.
+
+For now, wrong usages are just marked as deprecated, so there is **no breaking change**
+and it will just be reported by linters. But they may be removed in future releases.
+
+1. Cast without a JSON schema:
+```ts
+this.storage.get<User>('user');
+```
+was allowed but the result was still `unknown`.
+
+This is a very common misconception of client-side storage:
+you can store and get anything in storage, so many people think that casting as above
+is enough to get the right result type. It's not.
+
+Why? Because you're getting data from *client-side* storage:
+so it may have been modified (just go to your browser developer tools and hack what you want).
+
+A cast is just an information for *compilation*:
+it basically says to TypeScript: "believe me, it will be a `User`".
+But **that's not true: you're not sure you'll get a `User`**.
+
+This is why this library provides a *runtime* validation system,
+via a JSON schema as the second parameter.
+
+Be sure to read the [validation guide](https://github.com/cyrilletuzi/angular-async-local-storage/blob/master/docs/WATCHING.md) for all the why and how of validation.
+
+2. Mismatch between cast and simple JSON schema:
+```ts
+this.storage.get<number>('name', { type: 'string' });
+```
+was allowed but is of course an error. Now the match between the cast and simple JSON schemas (string, number, boolean and array of these) is checked.
+
+Note that in this scenario, the cast is not needed at all, it will be automatically inferred by the lib, so just do:
+```ts
+this.storage.get('name', { type: 'string' });
+```
+
 ## More documentation
 
 - [Full changelog for v11](../CHANGELOG.md)

--- a/projects/ngx-pwa/local-storage/src/lib/storages/get-overloads.spec.ts
+++ b/projects/ngx-pwa/local-storage/src/lib/storages/get-overloads.spec.ts
@@ -31,7 +31,8 @@ describe('get() API', () => {
   it('no schema / cast', (done) => {
 
     // @ts-expect-error
-    storageService.get<number>('test').subscribe((_) => {
+    // tslint:disable-next-line: deprecation
+    storageService.get<number>('test').subscribe((_: number) => {
 
       expect().nothing();
 
@@ -44,7 +45,8 @@ describe('get() API', () => {
   it('schema / wrong cast', (done) => {
 
     // @ts-expect-error
-    storageService.get<number>('test', { type: 'string' }).subscribe((_) => {
+    // tslint:disable-next-line: deprecation
+    storageService.get<number>('test', { type: 'string' }).subscribe((_: number) => {
 
       expect().nothing();
 
@@ -275,6 +277,7 @@ describe('get() API', () => {
     }
 
     // @ts-expect-error
+    // tslint:disable-next-line: deprecation
     storageService.get<Test>('test').subscribe((_: Test) => {
 
       expect().nothing();

--- a/projects/ngx-pwa/local-storage/src/lib/storages/get-overloads.spec.ts
+++ b/projects/ngx-pwa/local-storage/src/lib/storages/get-overloads.spec.ts
@@ -1,0 +1,367 @@
+import { map } from 'rxjs/operators';
+
+import { MemoryDatabase } from '../databases/memory-database';
+import { JSONSchema, JSONSchemaArrayOf, JSONSchemaNumber } from '../validation/json-schema';
+import { StorageMap } from './storage-map.service';
+
+describe('get() API', () => {
+
+  let storageService: StorageMap;
+
+  beforeEach(() => {
+
+    /* Do compilation tests on memory storage to avoid issues when other storages are not available */
+    storageService = new StorageMap(new MemoryDatabase());
+
+  });
+
+  it('no schema / no cast', (done) => {
+
+    // @ts-expect-error
+    storageService.get('test').subscribe((_: number) => {
+
+      expect().nothing();
+
+      done();
+
+    });
+
+  });
+
+  it('no schema / cast', (done) => {
+
+    // @ts-expect-error
+    storageService.get<number>('test').subscribe((_) => {
+
+      expect().nothing();
+
+      done();
+
+    });
+
+  });
+
+  it('schema / wrong cast', (done) => {
+
+    // @ts-expect-error
+    storageService.get<number>('test', { type: 'string' }).subscribe((_) => {
+
+      expect().nothing();
+
+      done();
+
+    });
+
+  });
+
+  it('literal basic schema / no cast', (done) => {
+
+    storageService.get('test', { type: 'number' }).subscribe((_: number | undefined) => {
+
+      expect().nothing();
+
+      done();
+
+    });
+
+  });
+
+  it('literal basic schema / cast', (done) => {
+
+    storageService.get<number>('test', { type: 'number' }).subscribe((_: number | undefined) => {
+
+      expect().nothing();
+
+      done();
+
+    });
+
+  });
+
+  it('literal schema with options', (done) => {
+
+    storageService.get('test', { type: 'number', maximum: 10 }).subscribe((_: number | undefined) => {
+
+      expect().nothing();
+
+      done();
+
+    });
+
+  });
+
+  it('prepared schema with general interface', (done) => {
+
+    const schema: JSONSchema = { type: 'number' };
+
+    storageService.get('test', schema).subscribe((_: number | undefined) => {
+
+      expect().nothing();
+
+      done();
+
+    });
+
+  });
+
+  it('prepared schema with specific interface', (done) => {
+
+    const schema: JSONSchemaNumber = { type: 'number' };
+
+    storageService.get('test', schema).subscribe((_: number | undefined) => {
+
+      expect().nothing();
+
+      done();
+
+    });
+
+  });
+
+  it('string', (done) => {
+
+    storageService.get('test', { type: 'string' }).subscribe((_: string | undefined) => {
+
+      expect().nothing();
+
+      done();
+
+    });
+
+  });
+
+  it('number', (done) => {
+
+    storageService.get('test', { type: 'number' }).subscribe((_: number | undefined) => {
+
+      expect().nothing();
+
+      done();
+
+    });
+
+  });
+
+  it('integer', (done) => {
+
+    storageService.get('test', { type: 'integer' }).subscribe((_: number | undefined) => {
+
+      expect().nothing();
+
+      done();
+
+    });
+
+  });
+
+  it('boolean', (done) => {
+
+    storageService.get('test', { type: 'boolean' }).subscribe((_: boolean | undefined) => {
+
+      expect().nothing();
+
+      done();
+
+    });
+
+  });
+
+  it('array of strings', (done) => {
+
+    storageService.get('test', {
+      type: 'array',
+      items: { type: 'string' }
+    }).subscribe((_: string[] | undefined) => {
+
+      expect().nothing();
+
+      done();
+
+    });
+
+  });
+
+  it('array of numbers', (done) => {
+
+    storageService.get('test', {
+      type: 'array',
+      items: { type: 'number' }
+    }).subscribe((_: number[] | undefined) => {
+
+      expect().nothing();
+
+      done();
+
+    });
+
+  });
+
+  it('array of integers', (done) => {
+
+    storageService.get('test', {
+      type: 'array',
+      items: { type: 'integer' }
+    }).subscribe((_: number[] | undefined) => {
+
+      expect().nothing();
+
+      done();
+
+    });
+
+  });
+
+  it('array of booleans', (done) => {
+
+    storageService.get('test', {
+      type: 'array',
+      items: { type: 'boolean' }
+    }).subscribe((_: boolean[] | undefined) => {
+
+      expect().nothing();
+
+      done();
+
+    });
+
+  });
+
+  it('array with extra options', (done) => {
+
+    const schema: JSONSchemaArrayOf<JSONSchemaNumber> = {
+      type: 'array',
+      items: { type: 'number' },
+      maxItems: 5
+    };
+
+    storageService.get('test', schema).subscribe((_: number[] | undefined) => {
+
+      expect().nothing();
+
+      done();
+
+    });
+
+  });
+
+  it('array of objects', (done) => {
+
+    interface Test {
+      test: string;
+    }
+
+    storageService.get<Test[]>('test', {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          test: { type: 'string' }
+        }
+      }
+    }).subscribe((_: Test[] | undefined) => {
+
+      expect().nothing();
+
+      done();
+
+    });
+
+  });
+
+  it('objects / cast / no schema', (done) => {
+
+    interface Test {
+      test: string;
+    }
+
+    // @ts-expect-error
+    storageService.get<Test>('test').subscribe((_: Test) => {
+
+      expect().nothing();
+
+      done();
+
+    });
+
+  });
+
+  it('objects / no cast / schema', (done) => {
+
+    storageService.get('test', {
+      type: 'object',
+      properties: {
+        test: { type: 'string' }
+      }
+    // @ts-expect-error
+    }).subscribe((_: string) => {
+
+      expect().nothing();
+
+      done();
+
+    });
+
+  });
+
+  it('objects / cast / schema', (done) => {
+
+    interface Test {
+      test: string;
+    }
+
+    storageService.get<Test>('test', {
+      type: 'object',
+      properties: {
+        test: { type: 'string' }
+      }
+    }).subscribe((_: Test | undefined) => {
+
+      expect().nothing();
+
+      done();
+
+    });
+
+  });
+
+  it('Map', (done) => {
+
+    storageService.get<[string, number][]>('test', {
+      type: 'array',
+      items: {
+        type: 'array',
+        items: [
+          { type: 'string' },
+          { type: 'number' },
+        ],
+      },
+    }).pipe(
+      map((result) => new Map(result))
+    ).subscribe((_: Map<string, number>) => {
+
+      expect().nothing();
+
+      done();
+
+    });
+
+  });
+
+  it('Set', (done) => {
+
+    storageService.get('test', {
+      type: 'array',
+      items: { type: 'string' },
+    }).pipe(
+      map((result) => new Set(result))
+    ).subscribe((_: Set<string>) => {
+
+      expect().nothing();
+
+      done();
+
+    });
+
+  });
+
+});

--- a/projects/ngx-pwa/local-storage/src/lib/storages/local-storage.service.ts
+++ b/projects/ngx-pwa/local-storage/src/lib/storages/local-storage.service.ts
@@ -86,8 +86,7 @@ export class LocalStorage {
 
     }
 
-    // tslint:disable-next-line: deprecation
-    return this.storageMap.get<T>(key, schemaFinal).pipe(
+    return (schemaFinal ? this.storageMap.get<T>(key, schemaFinal): this.storageMap.get(key)).pipe(
       /* Transform `undefined` into `null` to align with `localStorage` API */
       map((value) => (value !== undefined) ? value : null),
     );

--- a/projects/ngx-pwa/local-storage/src/lib/storages/local-storage.service.ts
+++ b/projects/ngx-pwa/local-storage/src/lib/storages/local-storage.service.ts
@@ -77,16 +77,14 @@ export class LocalStorage {
   getItem<T = unknown>(key: string, schema?: JSONSchema): Observable<unknown>;
   getItem<T = unknown>(key: string, schema?: JSONSchema | { schema: JSONSchema } | undefined): Observable<unknown> {
 
-    let schemaFinal: JSONSchema | undefined;
-
     if (schema) {
 
       /* Backward compatibility with version <= 7 */
-      schemaFinal = ('schema' in schema) ? schema.schema : schema;
+      schema = ('schema' in schema) ? schema.schema : schema;
 
     }
 
-    return (schemaFinal ? this.storageMap.get<T>(key, schemaFinal): this.storageMap.get(key)).pipe(
+    return (schema ? this.storageMap.get<T>(key, schema) : this.storageMap.get(key)).pipe(
       /* Transform `undefined` into `null` to align with `localStorage` API */
       map((value) => (value !== undefined) ? value : null),
     );

--- a/projects/ngx-pwa/local-storage/src/lib/storages/local-storage.service.ts
+++ b/projects/ngx-pwa/local-storage/src/lib/storages/local-storage.service.ts
@@ -86,11 +86,8 @@ export class LocalStorage {
 
     }
 
-    return (
-      !schemaFinal ? this.storageMap.get(key) :
-      (schemaFinal.type !== 'array' && schemaFinal.type !== 'object') ? this.storageMap.get(key, schemaFinal) :
-      this.storageMap.get<T>(key, schemaFinal)
-    ).pipe(
+    // tslint:disable-next-line: deprecation
+    return this.storageMap.get<T>(key, schemaFinal).pipe(
       /* Transform `undefined` into `null` to align with `localStorage` API */
       map((value) => (value !== undefined) ? value : null),
     );

--- a/projects/ngx-pwa/local-storage/src/lib/storages/storage-map.service.ts
+++ b/projects/ngx-pwa/local-storage/src/lib/storages/storage-map.service.ts
@@ -4,7 +4,7 @@ import { mergeMap, catchError, tap } from 'rxjs/operators';
 
 import {
   JSONSchema, JSONSchemaBoolean, JSONSchemaInteger,
-  JSONSchemaNumber, JSONSchemaString, JSONSchemaArrayOf, JSONSchemaArray, JSONSchemaObject,
+  JSONSchemaNumber, JSONSchemaString, JSONSchemaArrayOf
 } from '../validation/json-schema';
 import { JSONValidator } from '../validation/json-validator';
 import { IndexedDBDatabase } from '../databases/indexeddb-database';
@@ -163,16 +163,45 @@ export class StorageMap {
    * });
    */
   get<T extends string = string>(key: string, schema: JSONSchemaString): Observable<string | undefined>;
+  /**
+   * @deprecated The cast is useless here and doesn't match the JSON schema. Just remove the cast.
+   * @see {@link https://github.com/cyrilletuzi/angular-async-local-storage/blob/master/docs/VALIDATION.md}
+   */
+  get<T = string>(key: string, schema: JSONSchemaString): Observable<string | undefined>;
   get<T extends number = number>(key: string, schema: JSONSchemaInteger | JSONSchemaNumber): Observable<number | undefined>;
+  /**
+   * @deprecated The cast is useless here and doesn't match the JSON schema. Just remove the cast.
+   * @see {@link https://github.com/cyrilletuzi/angular-async-local-storage/blob/master/docs/VALIDATION.md}
+   */
+  get<T = number>(key: string, schema: JSONSchemaInteger | JSONSchemaNumber): Observable<number | undefined>;
   get<T extends boolean = boolean>(key: string, schema: JSONSchemaBoolean): Observable<boolean | undefined>;
+  /**
+   * @deprecated The cast is useless here and doesn't match the JSON schema. Just remove the cast.
+   * @see {@link https://github.com/cyrilletuzi/angular-async-local-storage/blob/master/docs/VALIDATION.md}
+   */
+  get<T = boolean>(key: string, schema: JSONSchemaBoolean): Observable<boolean | undefined>;
   get<T extends string[] = string[]>(key: string, schema: JSONSchemaArrayOf<JSONSchemaString>): Observable<string[] | undefined>;
+  /**
+   * @deprecated The cast is useless here and doesn't match the JSON schema. Just remove the cast.
+   * @see {@link https://github.com/cyrilletuzi/angular-async-local-storage/blob/master/docs/VALIDATION.md}
+   */
+  get<T = string[]>(key: string, schema: JSONSchemaArrayOf<JSONSchemaString>): Observable<string[] | undefined>;
   get<T extends number[] = number[]>(key: string, schema: JSONSchemaArrayOf<JSONSchemaInteger | JSONSchemaNumber>): Observable<number[] | undefined>;
+  /**
+   * @deprecated The cast is useless here and doesn't match the JSON schema. Just remove the cast.
+   * @see {@link https://github.com/cyrilletuzi/angular-async-local-storage/blob/master/docs/VALIDATION.md}
+   */
+  get<T = number[]>(key: string, schema: JSONSchemaArrayOf<JSONSchemaInteger | JSONSchemaNumber>): Observable<number[] | undefined>;
   get<T extends boolean[] = boolean[]>(key: string, schema: JSONSchemaArrayOf<JSONSchemaBoolean>): Observable<boolean[] | undefined>;
+  /**
+   * @deprecated The cast is useless here and doesn't match the JSON schema. Just remove the cast.
+   * @see {@link https://github.com/cyrilletuzi/angular-async-local-storage/blob/master/docs/VALIDATION.md}
+   */
   get<T = boolean[]>(key: string, schema: JSONSchemaArrayOf<JSONSchemaBoolean>): Observable<boolean[] | undefined>;
-  get<T = unknown>(key: string, schema: JSONSchemaArray | JSONSchemaObject): Observable<T | undefined>;
+  get<T = unknown>(key: string, schema: JSONSchema): Observable<T | undefined>;
   get(key: string): Observable<unknown>;
   /**
-   * @deprecated You are using the library incorrectly. Please refer to the documentation.
+   * @deprecated The cast is useless here: as no JSON schema was provided for validation, the result will still be `unknown`.
    * @see {@link https://github.com/cyrilletuzi/angular-async-local-storage/blob/master/docs/VALIDATION.md}
    */
   get<T>(key: string, schema?: JSONSchema): Observable<unknown>;
@@ -330,15 +359,45 @@ export class StorageMap {
    * @returns An infinite `Observable` giving the current value
    */
   watch<T extends string = string>(key: string, schema: JSONSchemaString): Observable<string | undefined>;
-  watch<T extends number = number>(key: string, schema: JSONSchemaInteger | JSONSchemaNumber): Observable<number | undefined>;
+  /**
+   * @deprecated The cast is useless here and doesn't match the JSON schema. Just remove the cast.
+   * @see {@link https://github.com/cyrilletuzi/angular-async-local-storage/blob/master/docs/VALIDATION.md}
+   */
+  watch<T = string>(key: string, schema: JSONSchemaString): Observable<string | undefined>;
+  watch<T extends number = number>(key: string, schema: JSONSchemaInteger | JSONSchemaNumber): Observable<number | undefined>;
+  /**
+   * @deprecated The cast is useless here and doesn't match the JSON schema. Just remove the cast.
+   * @see {@link https://github.com/cyrilletuzi/angular-async-local-storage/blob/master/docs/VALIDATION.md}
+   */
+  watch<T = number>(key: string, schema: JSONSchemaInteger | JSONSchemaNumber): Observable<number | undefined>;
   watch<T extends boolean = boolean>(key: string, schema: JSONSchemaBoolean): Observable<boolean | undefined>;
+  /**
+   * @deprecated The cast is useless here and doesn't match the JSON schema. Just remove the cast.
+   * @see {@link https://github.com/cyrilletuzi/angular-async-local-storage/blob/master/docs/VALIDATION.md}
+   */
+  watch<T = boolean>(key: string, schema: JSONSchemaBoolean): Observable<boolean | undefined>;
   watch<T extends string[] = string[]>(key: string, schema: JSONSchemaArrayOf<JSONSchemaString>): Observable<string[] | undefined>;
-  watch<T extends number[] = number[]>(key: string, schema: JSONSchemaArrayOf<JSONSchemaInteger | JSONSchemaNumber>): Observable<number[] | undefined>;
+  /**
+   * @deprecated The cast is useless here and doesn't match the JSON schema. Just remove the cast.
+   * @see {@link https://github.com/cyrilletuzi/angular-async-local-storage/blob/master/docs/VALIDATION.md}
+   */
+  watch<T = string[]>(key: string, schema: JSONSchemaArrayOf<JSONSchemaString>): Observable<string[] | undefined>;
+  watch<T extends number[] = number[]>(key: string, schema: JSONSchemaArrayOf<JSONSchemaInteger | JSONSchemaNumber>): Observable<number[] | undefined>;
+  /**
+   * @deprecated The cast is useless here and doesn't match the JSON schema. Just remove the cast.
+   * @see {@link https://github.com/cyrilletuzi/angular-async-local-storage/blob/master/docs/VALIDATION.md}
+   */
+  watch<T = number[]>(key: string, schema: JSONSchemaArrayOf<JSONSchemaInteger | JSONSchemaNumber>): Observable<number[] | undefined>;
   watch<T extends boolean[] = boolean[]>(key: string, schema: JSONSchemaArrayOf<JSONSchemaBoolean>): Observable<boolean[] | undefined>;
+  /**
+   * @deprecated The cast is useless here and doesn't match the JSON schema. Just remove the cast.
+   * @see {@link https://github.com/cyrilletuzi/angular-async-local-storage/blob/master/docs/VALIDATION.md}
+   */
+  watch<T = boolean[]>(key: string, schema: JSONSchemaArrayOf<JSONSchemaBoolean>): Observable<boolean[] | undefined>;
   watch<T = unknown>(key: string, schema: JSONSchema): Observable<T | undefined>;
   watch(key: string): Observable<unknown>;
   /**
-   * @deprecated You are using the library incorrectly. Please refer to the documentation.
+   * @deprecated The cast is useless here: as no JSON schema was provided for validation, the result will still be `unknown`.
    * @see {@link https://github.com/cyrilletuzi/angular-async-local-storage/blob/master/docs/VALIDATION.md}
    */
   watch<T>(key: string, schema?: JSONSchema): Observable<unknown>;
@@ -356,8 +415,7 @@ export class StorageMap {
       this.notifiers.set(key, notifier);
 
       /* Get the current item value */
-      // tslint:disable-next-line: deprecation
-      this.get<T>(key, schema).subscribe({
+      (schema ? this.get<T>(key, schema) : this.get(key)).subscribe({
         next: (result) => notifier.next(result),
         error: (error) => notifier.error(error),
       });

--- a/projects/ngx-pwa/local-storage/src/lib/storages/storage-map.service.ts
+++ b/projects/ngx-pwa/local-storage/src/lib/storages/storage-map.service.ts
@@ -369,7 +369,7 @@ export class StorageMap {
    * @deprecated The cast is useless here and doesn't match the JSON schema. Just remove the cast.
    * @see {@link https://github.com/cyrilletuzi/angular-async-local-storage/blob/master/docs/VALIDATION.md}
    */
-  watch<T = number>(key: string, schema: JSONSchemaInteger | JSONSchemaNumber): Observable<number | undefined>;
+  watch<T = number>(key: string, schema: JSONSchemaInteger | JSONSchemaNumber): Observable<number | undefined>;
   watch<T extends boolean = boolean>(key: string, schema: JSONSchemaBoolean): Observable<boolean | undefined>;
   /**
    * @deprecated The cast is useless here and doesn't match the JSON schema. Just remove the cast.
@@ -387,7 +387,7 @@ export class StorageMap {
    * @deprecated The cast is useless here and doesn't match the JSON schema. Just remove the cast.
    * @see {@link https://github.com/cyrilletuzi/angular-async-local-storage/blob/master/docs/VALIDATION.md}
    */
-  watch<T = number[]>(key: string, schema: JSONSchemaArrayOf<JSONSchemaInteger | JSONSchemaNumber>): Observable<number[] | undefined>;
+  watch<T = number[]>(key: string, schema: JSONSchemaArrayOf<JSONSchemaInteger | JSONSchemaNumber>): Observable<number[] | undefined>;
   watch<T extends boolean[] = boolean[]>(key: string, schema: JSONSchemaArrayOf<JSONSchemaBoolean>): Observable<boolean[] | undefined>;
   /**
    * @deprecated The cast is useless here and doesn't match the JSON schema. Just remove the cast.

--- a/projects/ngx-pwa/local-storage/src/lib/storages/storage-map.service.ts
+++ b/projects/ngx-pwa/local-storage/src/lib/storages/storage-map.service.ts
@@ -168,8 +168,14 @@ export class StorageMap {
   get<T extends string[] = string[]>(key: string, schema: JSONSchemaArrayOf<JSONSchemaString>): Observable<string[] | undefined>;
   get<T extends number[] = number[]>(key: string, schema: JSONSchemaArrayOf<JSONSchemaInteger | JSONSchemaNumber>): Observable<number[] | undefined>;
   get<T extends boolean[] = boolean[]>(key: string, schema: JSONSchemaArrayOf<JSONSchemaBoolean>): Observable<boolean[] | undefined>;
+  get<T = boolean[]>(key: string, schema: JSONSchemaArrayOf<JSONSchemaBoolean>): Observable<boolean[] | undefined>;
   get<T = unknown>(key: string, schema: JSONSchemaArray | JSONSchemaObject): Observable<T | undefined>;
-  get(key: string, schema?: JSONSchema): Observable<unknown>;
+  get(key: string): Observable<unknown>;
+  /**
+   * @deprecated You are using the library incorrectly. Please refer to the documentation.
+   * @see {@link https://github.com/cyrilletuzi/angular-async-local-storage/blob/master/docs/VALIDATION.md}
+   */
+  get<T>(key: string, schema?: JSONSchema): Observable<unknown>;
   get<T = unknown>(key: string, schema?: JSONSchema): Observable<unknown> {
 
     /* Get the data in storage */
@@ -330,7 +336,12 @@ export class StorageMap {
   watch<T extends number[] = number[]>(key: string, schema: JSONSchemaArrayOf<JSONSchemaInteger | JSONSchemaNumber>): Observable<number[] | undefined>;
   watch<T extends boolean[] = boolean[]>(key: string, schema: JSONSchemaArrayOf<JSONSchemaBoolean>): Observable<boolean[] | undefined>;
   watch<T = unknown>(key: string, schema: JSONSchema): Observable<T | undefined>;
-  watch(key: string, schema?: JSONSchema): Observable<unknown>;
+  watch(key: string): Observable<unknown>;
+  /**
+   * @deprecated You are using the library incorrectly. Please refer to the documentation.
+   * @see {@link https://github.com/cyrilletuzi/angular-async-local-storage/blob/master/docs/VALIDATION.md}
+   */
+  watch<T>(key: string, schema?: JSONSchema): Observable<unknown>;
   watch<T = unknown>(key: string, schema?: JSONSchema): Observable<unknown> {
 
     /* Check if there is already a notifier and cast according to schema */
@@ -345,7 +356,8 @@ export class StorageMap {
       this.notifiers.set(key, notifier);
 
       /* Get the current item value */
-      this.get(key, schema).subscribe({
+      // tslint:disable-next-line: deprecation
+      this.get<T>(key, schema).subscribe({
         next: (result) => notifier.next(result),
         error: (error) => notifier.error(error),
       });

--- a/projects/ngx-pwa/local-storage/src/lib/storages/storage-map.service.ts
+++ b/projects/ngx-pwa/local-storage/src/lib/storages/storage-map.service.ts
@@ -4,7 +4,7 @@ import { mergeMap, catchError, tap } from 'rxjs/operators';
 
 import {
   JSONSchema, JSONSchemaBoolean, JSONSchemaInteger,
-  JSONSchemaNumber, JSONSchemaString, JSONSchemaArrayOf,
+  JSONSchemaNumber, JSONSchemaString, JSONSchemaArrayOf, JSONSchemaArray, JSONSchemaObject,
 } from '../validation/json-schema';
 import { JSONValidator } from '../validation/json-validator';
 import { IndexedDBDatabase } from '../databases/indexeddb-database';
@@ -162,14 +162,14 @@ export class StorageMap {
    *   }
    * });
    */
-  get<T = string>(key: string, schema: JSONSchemaString): Observable<string | undefined>;
-  get<T = number>(key: string, schema: JSONSchemaInteger | JSONSchemaNumber): Observable<number | undefined>;
-  get<T = boolean>(key: string, schema: JSONSchemaBoolean): Observable<boolean | undefined>;
-  get<T = string[]>(key: string, schema: JSONSchemaArrayOf<JSONSchemaString>): Observable<string[] | undefined>;
-  get<T = number[]>(key: string, schema: JSONSchemaArrayOf<JSONSchemaInteger | JSONSchemaNumber>): Observable<number[] | undefined>;
-  get<T = boolean[]>(key: string, schema: JSONSchemaArrayOf<JSONSchemaBoolean>): Observable<boolean[] | undefined>;
-  get<T = unknown>(key: string, schema: JSONSchema): Observable<T | undefined>;
-  get<T = unknown>(key: string, schema?: JSONSchema): Observable<unknown>;
+  get<T extends string = string>(key: string, schema: JSONSchemaString): Observable<string | undefined>;
+  get<T extends number = number>(key: string, schema: JSONSchemaInteger | JSONSchemaNumber): Observable<number | undefined>;
+  get<T extends boolean = boolean>(key: string, schema: JSONSchemaBoolean): Observable<boolean | undefined>;
+  get<T extends string[] = string[]>(key: string, schema: JSONSchemaArrayOf<JSONSchemaString>): Observable<string[] | undefined>;
+  get<T extends number[] = number[]>(key: string, schema: JSONSchemaArrayOf<JSONSchemaInteger | JSONSchemaNumber>): Observable<number[] | undefined>;
+  get<T extends boolean[] = boolean[]>(key: string, schema: JSONSchemaArrayOf<JSONSchemaBoolean>): Observable<boolean[] | undefined>;
+  get<T = unknown>(key: string, schema: JSONSchemaArray | JSONSchemaObject): Observable<T | undefined>;
+  get(key: string, schema?: JSONSchema): Observable<unknown>;
   get<T = unknown>(key: string, schema?: JSONSchema): Observable<unknown> {
 
     /* Get the data in storage */
@@ -323,14 +323,14 @@ export class StorageMap {
    * @param schema Optional JSON schema to validate the initial value
    * @returns An infinite `Observable` giving the current value
    */
-  watch<T = string>(key: string, schema: JSONSchemaString): Observable<string | undefined>;
-  watch<T = number>(key: string, schema: JSONSchemaInteger | JSONSchemaNumber): Observable<number | undefined>;
-  watch<T = boolean>(key: string, schema: JSONSchemaBoolean): Observable<boolean | undefined>;
-  watch<T = string[]>(key: string, schema: JSONSchemaArrayOf<JSONSchemaString>): Observable<string[] | undefined>;
-  watch<T = number[]>(key: string, schema: JSONSchemaArrayOf<JSONSchemaInteger | JSONSchemaNumber>): Observable<number[] | undefined>;
-  watch<T = boolean[]>(key: string, schema: JSONSchemaArrayOf<JSONSchemaBoolean>): Observable<boolean[] | undefined>;
+  watch<T extends string = string>(key: string, schema: JSONSchemaString): Observable<string | undefined>;
+  watch<T extends number = number>(key: string, schema: JSONSchemaInteger | JSONSchemaNumber): Observable<number | undefined>;
+  watch<T extends boolean = boolean>(key: string, schema: JSONSchemaBoolean): Observable<boolean | undefined>;
+  watch<T extends string[] = string[]>(key: string, schema: JSONSchemaArrayOf<JSONSchemaString>): Observable<string[] | undefined>;
+  watch<T extends number[] = number[]>(key: string, schema: JSONSchemaArrayOf<JSONSchemaInteger | JSONSchemaNumber>): Observable<number[] | undefined>;
+  watch<T extends boolean[] = boolean[]>(key: string, schema: JSONSchemaArrayOf<JSONSchemaBoolean>): Observable<boolean[] | undefined>;
   watch<T = unknown>(key: string, schema: JSONSchema): Observable<T | undefined>;
-  watch<T = unknown>(key: string, schema?: JSONSchema): Observable<unknown>;
+  watch(key: string, schema?: JSONSchema): Observable<unknown>;
   watch<T = unknown>(key: string, schema?: JSONSchema): Observable<unknown> {
 
     /* Check if there is already a notifier and cast according to schema */
@@ -345,7 +345,7 @@ export class StorageMap {
       this.notifiers.set(key, notifier);
 
       /* Get the current item value */
-      this.get<T>(key, schema).subscribe({
+      this.get(key, schema).subscribe({
         next: (result) => notifier.next(result),
         error: (error) => notifier.error(error),
       });

--- a/tslint.json
+++ b/tslint.json
@@ -30,7 +30,7 @@
     "max-classes-per-file": false,
     "max-line-length": [
       true,
-      140
+      160
     ],
     "member-ordering": [
       true,


### PR DESCRIPTION
This PR changes the `.get()`/`.watch()` overloads to better match the behavior of the lib. Wrong usages will be reported as deprecated.

1. Cast without a JSON schema:
```ts
this.storage.get<User>('user');
```
was allowed but the result was still `unknown`: as you're getting data from *client-side* storage, it may have been modified, so without a *runtime* validation with the second parameter, you really don't known what you get.

This will avoid a common confusion about how client-side storage works.

2. Mismatch between cast and simple JSON schema:
```ts
this.storage.get<number>('name', { type: 'string' });
```
was allowed but is of course an error. Now the match between the cast and simple JSON schemas (string, number, boolean and array of these) is checked.

Note that in this scenario, the cast is not needed at all, it will be automatically inferred by the lib, so just do:
```ts
this.storage.get('name', { type: 'string' });
```

Be sure to read the [validation guide](https://github.com/cyrilletuzi/angular-async-local-storage/blob/master/docs/WATCHING.md) for all the why and how of validation.

Fixes #462 