### PR TITLE
fix: use generic when constraint is ok, to allow custom strings/numbers

### DIFF
--- a/projects/ngx-pwa/local-storage/src/lib/storages/get-overloads.spec.ts
+++ b/projects/ngx-pwa/local-storage/src/lib/storages/get-overloads.spec.ts
@@ -242,6 +242,23 @@ describe('get() API', () => {
 
   });
 
+  it('special readonly array of strings', (done) => {
+
+    type Themes = readonly ('dark' | 'light')[];
+
+    storageService.get<Themes>('test', {
+      type: 'array',
+      items: { type: 'string' }
+    }).subscribe((_: Themes | undefined) => {
+
+      expect().nothing();
+
+      done();
+
+    });
+
+  });
+
   it('array of numbers', (done) => {
 
     storageService.get('test', {
@@ -260,6 +277,23 @@ describe('get() API', () => {
   it('special array of numbers', (done) => {
 
     type NumbersArray = (1 | 2)[];
+
+    storageService.get<NumbersArray>('test', {
+      type: 'array',
+      items: { type: 'number' }
+    }).subscribe((_: NumbersArray | undefined) => {
+
+      expect().nothing();
+
+      done();
+
+    });
+
+  });
+
+  it('special readonly array of numbers', (done) => {
+
+    type NumbersArray = readonly (1 | 2)[];
 
     storageService.get<NumbersArray>('test', {
       type: 'array',

--- a/projects/ngx-pwa/local-storage/src/lib/storages/get-overloads.spec.ts
+++ b/projects/ngx-pwa/local-storage/src/lib/storages/get-overloads.spec.ts
@@ -132,6 +132,20 @@ describe('get() API', () => {
 
   });
 
+  it('special string', (done) => {
+
+    type Theme = 'dark' | 'light';
+
+    storageService.get<Theme>('test', { type: 'string' }).subscribe((_: Theme | undefined) => {
+
+      expect().nothing();
+
+      done();
+
+    });
+
+  });
+
   it('number', (done) => {
 
     storageService.get('test', { type: 'number' }).subscribe((_: number | undefined) => {
@@ -144,9 +158,37 @@ describe('get() API', () => {
 
   });
 
+  it('special number', (done) => {
+
+    type SomeNumbers = 1.5 | 2.5;
+
+    storageService.get<SomeNumbers>('test', { type: 'number' }).subscribe((_: SomeNumbers | undefined) => {
+
+      expect().nothing();
+
+      done();
+
+    });
+
+  });
+
   it('integer', (done) => {
 
     storageService.get('test', { type: 'integer' }).subscribe((_: number | undefined) => {
+
+      expect().nothing();
+
+      done();
+
+    });
+
+  });
+
+  it('integer', (done) => {
+
+    type SpecialIntegers = 1 | 2;
+
+    storageService.get<SpecialIntegers>('test', { type: 'integer' }).subscribe((_: SpecialIntegers | undefined) => {
 
       expect().nothing();
 
@@ -183,12 +225,46 @@ describe('get() API', () => {
 
   });
 
+  it('special array of strings', (done) => {
+
+    type Themes = ('dark' | 'light')[];
+
+    storageService.get<Themes>('test', {
+      type: 'array',
+      items: { type: 'string' }
+    }).subscribe((_: Themes | undefined) => {
+
+      expect().nothing();
+
+      done();
+
+    });
+
+  });
+
   it('array of numbers', (done) => {
 
     storageService.get('test', {
       type: 'array',
       items: { type: 'number' }
     }).subscribe((_: number[] | undefined) => {
+
+      expect().nothing();
+
+      done();
+
+    });
+
+  });
+
+  it('special array of numbers', (done) => {
+
+    type NumbersArray = (1 | 2)[];
+
+    storageService.get<NumbersArray>('test', {
+      type: 'array',
+      items: { type: 'number' }
+    }).subscribe((_: NumbersArray | undefined) => {
 
       expect().nothing();
 

--- a/projects/ngx-pwa/local-storage/src/lib/storages/storage-map.service.ts
+++ b/projects/ngx-pwa/local-storage/src/lib/storages/storage-map.service.ts
@@ -162,37 +162,37 @@ export class StorageMap {
    *   }
    * });
    */
-  get<T extends string = string>(key: string, schema: JSONSchemaString): Observable<string | undefined>;
+  get<T extends string = string>(key: string, schema: JSONSchemaString): Observable<T | undefined>;
   /**
    * @deprecated The cast is useless here and doesn't match the JSON schema. Just remove the cast.
    * @see {@link https://github.com/cyrilletuzi/angular-async-local-storage/blob/master/docs/VALIDATION.md}
    */
   get<T = string>(key: string, schema: JSONSchemaString): Observable<string | undefined>;
-  get<T extends number = number>(key: string, schema: JSONSchemaInteger | JSONSchemaNumber): Observable<number | undefined>;
+  get<T extends number = number>(key: string, schema: JSONSchemaInteger | JSONSchemaNumber): Observable<T | undefined>;
   /**
    * @deprecated The cast is useless here and doesn't match the JSON schema. Just remove the cast.
    * @see {@link https://github.com/cyrilletuzi/angular-async-local-storage/blob/master/docs/VALIDATION.md}
    */
   get<T = number>(key: string, schema: JSONSchemaInteger | JSONSchemaNumber): Observable<number | undefined>;
-  get<T extends boolean = boolean>(key: string, schema: JSONSchemaBoolean): Observable<boolean | undefined>;
+  get<T extends boolean = boolean>(key: string, schema: JSONSchemaBoolean): Observable<T | undefined>;
   /**
    * @deprecated The cast is useless here and doesn't match the JSON schema. Just remove the cast.
    * @see {@link https://github.com/cyrilletuzi/angular-async-local-storage/blob/master/docs/VALIDATION.md}
    */
   get<T = boolean>(key: string, schema: JSONSchemaBoolean): Observable<boolean | undefined>;
-  get<T extends string[] = string[]>(key: string, schema: JSONSchemaArrayOf<JSONSchemaString>): Observable<string[] | undefined>;
+  get<T extends string[] = string[]>(key: string, schema: JSONSchemaArrayOf<JSONSchemaString>): Observable<T | undefined>;
   /**
    * @deprecated The cast is useless here and doesn't match the JSON schema. Just remove the cast.
    * @see {@link https://github.com/cyrilletuzi/angular-async-local-storage/blob/master/docs/VALIDATION.md}
    */
   get<T = string[]>(key: string, schema: JSONSchemaArrayOf<JSONSchemaString>): Observable<string[] | undefined>;
-  get<T extends number[] = number[]>(key: string, schema: JSONSchemaArrayOf<JSONSchemaInteger | JSONSchemaNumber>): Observable<number[] | undefined>;
+  get<T extends number[] = number[]>(key: string, schema: JSONSchemaArrayOf<JSONSchemaInteger | JSONSchemaNumber>): Observable<T | undefined>;
   /**
    * @deprecated The cast is useless here and doesn't match the JSON schema. Just remove the cast.
    * @see {@link https://github.com/cyrilletuzi/angular-async-local-storage/blob/master/docs/VALIDATION.md}
    */
   get<T = number[]>(key: string, schema: JSONSchemaArrayOf<JSONSchemaInteger | JSONSchemaNumber>): Observable<number[] | undefined>;
-  get<T extends boolean[] = boolean[]>(key: string, schema: JSONSchemaArrayOf<JSONSchemaBoolean>): Observable<boolean[] | undefined>;
+  get<T extends boolean[] = boolean[]>(key: string, schema: JSONSchemaArrayOf<JSONSchemaBoolean>): Observable<T | undefined>;
   /**
    * @deprecated The cast is useless here and doesn't match the JSON schema. Just remove the cast.
    * @see {@link https://github.com/cyrilletuzi/angular-async-local-storage/blob/master/docs/VALIDATION.md}

--- a/projects/ngx-pwa/local-storage/src/lib/storages/storage-map.service.ts
+++ b/projects/ngx-pwa/local-storage/src/lib/storages/storage-map.service.ts
@@ -358,37 +358,37 @@ export class StorageMap {
    * @param schema Optional JSON schema to validate the initial value
    * @returns An infinite `Observable` giving the current value
    */
-  watch<T extends string = string>(key: string, schema: JSONSchemaString): Observable<string | undefined>;
+  watch<T extends string = string>(key: string, schema: JSONSchemaString): Observable<T | undefined>;
   /**
    * @deprecated The cast is useless here and doesn't match the JSON schema. Just remove the cast.
    * @see {@link https://github.com/cyrilletuzi/angular-async-local-storage/blob/master/docs/VALIDATION.md}
    */
   watch<T = string>(key: string, schema: JSONSchemaString): Observable<string | undefined>;
-  watch<T extends number = number>(key: string, schema: JSONSchemaInteger | JSONSchemaNumber): Observable<number | undefined>;
+  watch<T extends number = number>(key: string, schema: JSONSchemaInteger | JSONSchemaNumber): Observable<T | undefined>;
   /**
    * @deprecated The cast is useless here and doesn't match the JSON schema. Just remove the cast.
    * @see {@link https://github.com/cyrilletuzi/angular-async-local-storage/blob/master/docs/VALIDATION.md}
    */
   watch<T = number>(key: string, schema: JSONSchemaInteger | JSONSchemaNumber): Observable<number | undefined>;
-  watch<T extends boolean = boolean>(key: string, schema: JSONSchemaBoolean): Observable<boolean | undefined>;
+  watch<T extends boolean = boolean>(key: string, schema: JSONSchemaBoolean): Observable<T | undefined>;
   /**
    * @deprecated The cast is useless here and doesn't match the JSON schema. Just remove the cast.
    * @see {@link https://github.com/cyrilletuzi/angular-async-local-storage/blob/master/docs/VALIDATION.md}
    */
   watch<T = boolean>(key: string, schema: JSONSchemaBoolean): Observable<boolean | undefined>;
-  watch<T extends string[] = string[]>(key: string, schema: JSONSchemaArrayOf<JSONSchemaString>): Observable<string[] | undefined>;
+  watch<T extends string[] = string[]>(key: string, schema: JSONSchemaArrayOf<JSONSchemaString>): Observable<T | undefined>;
   /**
    * @deprecated The cast is useless here and doesn't match the JSON schema. Just remove the cast.
    * @see {@link https://github.com/cyrilletuzi/angular-async-local-storage/blob/master/docs/VALIDATION.md}
    */
   watch<T = string[]>(key: string, schema: JSONSchemaArrayOf<JSONSchemaString>): Observable<string[] | undefined>;
-  watch<T extends number[] = number[]>(key: string, schema: JSONSchemaArrayOf<JSONSchemaInteger | JSONSchemaNumber>): Observable<number[] | undefined>;
+  watch<T extends number[] = number[]>(key: string, schema: JSONSchemaArrayOf<JSONSchemaInteger | JSONSchemaNumber>): Observable<T | undefined>;
   /**
    * @deprecated The cast is useless here and doesn't match the JSON schema. Just remove the cast.
    * @see {@link https://github.com/cyrilletuzi/angular-async-local-storage/blob/master/docs/VALIDATION.md}
    */
   watch<T = number[]>(key: string, schema: JSONSchemaArrayOf<JSONSchemaInteger | JSONSchemaNumber>): Observable<number[] | undefined>;
-  watch<T extends boolean[] = boolean[]>(key: string, schema: JSONSchemaArrayOf<JSONSchemaBoolean>): Observable<boolean[] | undefined>;
+  watch<T extends boolean[] = boolean[]>(key: string, schema: JSONSchemaArrayOf<JSONSchemaBoolean>): Observable<T | undefined>;
   /**
    * @deprecated The cast is useless here and doesn't match the JSON schema. Just remove the cast.
    * @see {@link https://github.com/cyrilletuzi/angular-async-local-storage/blob/master/docs/VALIDATION.md}

--- a/projects/ngx-pwa/local-storage/src/lib/storages/storage-map.service.ts
+++ b/projects/ngx-pwa/local-storage/src/lib/storages/storage-map.service.ts
@@ -180,19 +180,19 @@ export class StorageMap {
    * @see {@link https://github.com/cyrilletuzi/angular-async-local-storage/blob/master/docs/VALIDATION.md}
    */
   get<T = boolean>(key: string, schema: JSONSchemaBoolean): Observable<boolean | undefined>;
-  get<T extends string[] = string[]>(key: string, schema: JSONSchemaArrayOf<JSONSchemaString>): Observable<T | undefined>;
+  get<T extends readonly string[] = string[]>(key: string, schema: JSONSchemaArrayOf<JSONSchemaString>): Observable<T | undefined>;
   /**
    * @deprecated The cast is useless here and doesn't match the JSON schema. Just remove the cast.
    * @see {@link https://github.com/cyrilletuzi/angular-async-local-storage/blob/master/docs/VALIDATION.md}
    */
   get<T = string[]>(key: string, schema: JSONSchemaArrayOf<JSONSchemaString>): Observable<string[] | undefined>;
-  get<T extends number[] = number[]>(key: string, schema: JSONSchemaArrayOf<JSONSchemaInteger | JSONSchemaNumber>): Observable<T | undefined>;
+  get<T extends readonly number[] = number[]>(key: string, schema: JSONSchemaArrayOf<JSONSchemaInteger | JSONSchemaNumber>): Observable<T | undefined>;
   /**
    * @deprecated The cast is useless here and doesn't match the JSON schema. Just remove the cast.
    * @see {@link https://github.com/cyrilletuzi/angular-async-local-storage/blob/master/docs/VALIDATION.md}
    */
   get<T = number[]>(key: string, schema: JSONSchemaArrayOf<JSONSchemaInteger | JSONSchemaNumber>): Observable<number[] | undefined>;
-  get<T extends boolean[] = boolean[]>(key: string, schema: JSONSchemaArrayOf<JSONSchemaBoolean>): Observable<T | undefined>;
+  get<T extends readonly boolean[] = boolean[]>(key: string, schema: JSONSchemaArrayOf<JSONSchemaBoolean>): Observable<T | undefined>;
   /**
    * @deprecated The cast is useless here and doesn't match the JSON schema. Just remove the cast.
    * @see {@link https://github.com/cyrilletuzi/angular-async-local-storage/blob/master/docs/VALIDATION.md}
@@ -376,19 +376,19 @@ export class StorageMap {
    * @see {@link https://github.com/cyrilletuzi/angular-async-local-storage/blob/master/docs/VALIDATION.md}
    */
   watch<T = boolean>(key: string, schema: JSONSchemaBoolean): Observable<boolean | undefined>;
-  watch<T extends string[] = string[]>(key: string, schema: JSONSchemaArrayOf<JSONSchemaString>): Observable<T | undefined>;
+  watch<T extends readonly string[] = string[]>(key: string, schema: JSONSchemaArrayOf<JSONSchemaString>): Observable<T | undefined>;
   /**
    * @deprecated The cast is useless here and doesn't match the JSON schema. Just remove the cast.
    * @see {@link https://github.com/cyrilletuzi/angular-async-local-storage/blob/master/docs/VALIDATION.md}
    */
   watch<T = string[]>(key: string, schema: JSONSchemaArrayOf<JSONSchemaString>): Observable<string[] | undefined>;
-  watch<T extends number[] = number[]>(key: string, schema: JSONSchemaArrayOf<JSONSchemaInteger | JSONSchemaNumber>): Observable<T | undefined>;
+  watch<T extends readonly number[] = number[]>(key: string, schema: JSONSchemaArrayOf<JSONSchemaInteger | JSONSchemaNumber>): Observable<T | undefined>;
   /**
    * @deprecated The cast is useless here and doesn't match the JSON schema. Just remove the cast.
    * @see {@link https://github.com/cyrilletuzi/angular-async-local-storage/blob/master/docs/VALIDATION.md}
    */
   watch<T = number[]>(key: string, schema: JSONSchemaArrayOf<JSONSchemaInteger | JSONSchemaNumber>): Observable<number[] | undefined>;
-  watch<T extends boolean[] = boolean[]>(key: string, schema: JSONSchemaArrayOf<JSONSchemaBoolean>): Observable<T | undefined>;
+  watch<T extends readonly boolean[] = boolean[]>(key: string, schema: JSONSchemaArrayOf<JSONSchemaBoolean>): Observable<T | undefined>;
   /**
    * @deprecated The cast is useless here and doesn't match the JSON schema. Just remove the cast.
    * @see {@link https://github.com/cyrilletuzi/angular-async-local-storage/blob/master/docs/VALIDATION.md}


### PR DESCRIPTION
Follow up of @dev054 comments about #468 

Note that, as for objects, you're not sure the custom type will be right if it doesn't match your JSON schema.

```ts
type Theme = 'dark' | 'light';
this.storage.get<Theme>('theme', { type: 'string' });
```
should be:
```ts
type Theme = 'dark' | 'light';
this.storage.get<Theme>('theme', { type: 'string', enum: ['dark, 'light'] });
```
