### PR TITLE
feat: allow readonly arrays in JSON schema

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,7 +62,7 @@ jobs:
 
   test-minimum:
 
-    name: Test with Angular@10.0.0 and minimum dependencies requirements
+    name: Test with Angular@11.0.0 and minimum dependencies requirements
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
@@ -79,7 +79,7 @@ jobs:
     - name: Build the lib (with the current version, as it is what is published on npm)
       run: npm run build
     - name: Downgrade dependencies to minimal required version
-      run: npm install typescript@4.0.2 tslib@2.0.0 rxjs@6.5.3 zone.js@0.10.3 @angular/common@10.0.0 @angular/compiler@10.0.0 @angular/core@10.0.0 @angular/platform-browser@10.0.0 @angular/platform-browser-dynamic@10.0.0 @angular/router@10.0.0 @angular/cli@10.0.0 @angular/compiler-cli@10.0.0 @angular-devkit/build-angular@0.1000.0
+      run: npm install typescript@4.0.2 tslib@2.0.0 rxjs@6.5.3 zone.js@0.10.3 @angular/common@next @angular/compiler@next @angular/core@next @angular/platform-browser@next @angular/platform-browser-dynamic@next @angular/router@next @angular/cli@next @angular/compiler-cli@next @angular-devkit/build-angular@next
       env:
         CI: true
     - name: Run unit tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This lib is fully documented and so you'll find detailed [migration guides](./MIGRATION.md).
 
-## 11.0.0-0 (2020-10-19)
+## 11.0.0-2 (2020-10-22)
 
 **This is a pre-release version. Do NOT use in production.**
 
@@ -49,6 +49,19 @@ Note that in this scenario, the cast is not needed at all, it will be automatica
 ```ts
 this.storage.get('name', { type: 'string' });
 ```
+
+3. JSON schema `as const`
+
+Given how JSON schema works, it is better to set them `as const`:
+
+```ts
+this.storage.get('name', { type: 'string' } as const);
+```
+
+But before v11, it was not possible when the JSON schema was using properties of array type
+(`enum`, `items`, `required`). This is now fixed, and is a first step toward
+auto-inferring the type from the JSON schema in all scenarios
+((#463)[https://github.com/cyrilletuzi/angular-async-local-storage/issues/463]).
 
 ## 10.1.0 (2020-09-03)
 

--- a/projects/ngx-pwa/local-storage/src/lib/storages/get-overloads.spec.ts
+++ b/projects/ngx-pwa/local-storage/src/lib/storages/get-overloads.spec.ts
@@ -477,4 +477,33 @@ describe('get() API', () => {
 
   });
 
+  it('schema as const', (done) => {
+
+    interface Test {
+      test: string;
+    }
+
+    storageService.get<Test>('test', {
+      type: 'object',
+      properties: {
+        test: {
+          type: 'string',
+          enum: ['hello', 'world'],
+        },
+        list: {
+          type: 'array',
+          items: [{ type: 'string' }, { type: 'number' }],
+        },
+      },
+      required: ['test'],
+    } as const).subscribe((_: Test | undefined) => {
+
+      expect().nothing();
+
+      done();
+
+    });
+
+  });
+
 });

--- a/projects/ngx-pwa/local-storage/src/lib/validation/json-schema.ts
+++ b/projects/ngx-pwa/local-storage/src/lib/validation/json-schema.ts
@@ -37,7 +37,7 @@ export interface JSONSchemaNumber {
   /**
    * Checks if a value is strictly equal to one of the value of enum.
    */
-  enum?: number[];
+  enum?: readonly number[];
 
   /**
    * Check if a number is a multiple of x.
@@ -85,7 +85,7 @@ export interface JSONSchemaInteger {
   /**
    * Checks if a value is strictly equal to one of the value of enum.
    */
-  enum?: number[];
+  enum?: readonly number[];
 
   /**
    * Check if a number is a multiple of x.
@@ -133,7 +133,7 @@ export interface JSONSchemaString {
   /**
    * Checks if a value is strictly equal to one of the value of enum.
    */
-  enum?: string[];
+  enum?: readonly string[];
 
   /**
    * Maxium length for a string.
@@ -168,7 +168,7 @@ export interface JSONSchemaArray {
   /**
    * Schema for the values of an array, or array of schemas for a tuple.
    */
-  items: JSONSchema | JSONSchema[];
+  items: JSONSchema | readonly JSONSchema[];
 
   /**
    * Check if an array length is lower or equal to this value.
@@ -248,7 +248,7 @@ export interface JSONSchemaObject {
    * Array of names of the required properties for an object.
    * Properties set as required should be present in `properties` too.
    */
-  required?: string[];
+  required?: readonly string[];
 
 }
 

--- a/projects/ngx-pwa/local-storage/src/lib/validation/json-validator.ts
+++ b/projects/ngx-pwa/local-storage/src/lib/validation/json-validator.ts
@@ -196,7 +196,9 @@ export class JSONValidator {
     /* Validate all the values in array */
     for (const value of data) {
 
-      if (!this.validate(value, schema.items)) {
+      // TODO: remove when TypeScript 4.1 is available
+      // (currently the type narrowed type from `Array.isArray()` is lost on readonly arrays)
+      if (!this.validate(value, schema.items as JSONSchema)) {
         return false;
       }
 

--- a/projects/ngx-pwa/local-storage/src/lib/validation/json-validator.ts
+++ b/projects/ngx-pwa/local-storage/src/lib/validation/json-validator.ts
@@ -197,7 +197,7 @@ export class JSONValidator {
     for (const value of data) {
 
       // TODO: remove when TypeScript 4.1 is available
-      // (currently the type narrowed type from `Array.isArray()` is lost on readonly arrays)
+      // (currently the narrowed type from `Array.isArray()` is lost on readonly arrays)
       if (!this.validate(value, schema.items as JSONSchema)) {
         return false;
       }


### PR DESCRIPTION
Given how JSON schema works, it is better to set them `as const`:

```ts
this.storage.get('name', { type: 'string' } as const);
```

But before v11, it was not possible when the JSON schema was using properties of array type (`enum`, `items`, `required`). This is now fixed, and is a first step toward auto-inferring the type from the JSON schema in all scenarios (#463).

Fixes #470 