### PR TITLE
use satisfies instead of direct type for JSONSchema

### DIFF
--- a/docs/MIGRATION_TO_V16.md
+++ b/docs/MIGRATION_TO_V16.md
@@ -87,6 +87,9 @@ const schema: JSONSchemaString = { type: 'string' };
 const schema = { type: 'string' } satisfies JSONSchema;
 ```
 
+> [!TIP]
+> If you wonder why `satisfies JSONSchema` instead of `schema: JSONSchema`, check [this Pull Request](https://github.com/cyrilletuzi/angular-async-local-storage/pull/1002).
+
 ### JSONValidator
 
 `JSONValidator` is deprecated and will no longer be available in version 17. It is an internal utility class which is limited, could change at any time and is out of scope of this library.

--- a/docs/MIGRATION_TO_V16.md
+++ b/docs/MIGRATION_TO_V16.md
@@ -84,7 +84,7 @@ Example:
 const schema: JSONSchemaString = { type: 'string' };
 
 // After
-const schema: JSONSchema = { type: 'string' };
+const schema = { type: 'string' } satisfies JSONSchema;
 ```
 
 ### JSONValidator

--- a/docs/MIGRATION_TO_V17.md
+++ b/docs/MIGRATION_TO_V17.md
@@ -91,7 +91,7 @@ Example:
 const schema: JSONSchemaString = { type: "string" };
 
 // After
-const schema: JSONSchema = { type: "string" };
+const schema = { type: "string" } satisfies JSONSchema;
 ```
 
 ### JSONValidator

--- a/docs/MIGRATION_TO_V17.md
+++ b/docs/MIGRATION_TO_V17.md
@@ -94,6 +94,9 @@ const schema: JSONSchemaString = { type: "string" };
 const schema = { type: "string" } satisfies JSONSchema;
 ```
 
+> [!TIP]
+> If you wonder why `satisfies JSONSchema` instead of `schema: JSONSchema`, check [this Pull Request](https://github.com/cyrilletuzi/angular-async-local-storage/pull/1002).
+
 ### JSONValidator
 
 `JSONValidator` is removed. It was an internal utility class which is limited,

--- a/docs/SERIALIZATION.md
+++ b/docs/SERIALIZATION.md
@@ -42,7 +42,7 @@ const someMap = new Map<string, number>([['hello', 1], ['world', 2]]);
 this.storage.set('test', Array.from(someMap)).subscribe();
 
 /* Reading */
-const schema: JSONSchema = {
+const schema = {
   type: 'array',
   items: {
     type: 'array',
@@ -51,7 +51,7 @@ const schema: JSONSchema = {
       { type: 'number' },
     ],
   },
-};
+} satisfies JSONSchema;
 
 this.storage.get<[string, number][]>('test', schema).pipe(
   map((dataArray) => new Map(dataArray)),
@@ -69,10 +69,10 @@ const someSet = new Set<string>(['hello', 'world']);
 this.storage.set('test', Array.from(someSet)).subscribe();
 
 /* Reading */
-const schema: JSONSchema = {
+const schema = {
   type: 'array',
   items: { type: 'string' },
-};
+} satisfies JSONSchema;
 
 this.storage.get('test', schema).pipe(
   map((dataArray) => new Set(dataArray)),

--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -123,7 +123,7 @@ interface User {
   favoriteColors: string[];
 }
 
-const schema: JSONSchema = {
+const schema = {
   type: 'object',
   properties: {
     name: { type: 'string' },
@@ -137,7 +137,7 @@ const schema: JSONSchema = {
     },
   },
   required: ['name', 'isAuthenticated', 'favoriteColors']
-};
+} satisfies JSONSchema;
 
 this.storage.get<User>('test', schema)
 

--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -140,8 +140,13 @@ const schema = {
 } satisfies JSONSchema;
 
 this.storage.get<User>('test', schema)
+```
 
-// typebox
+> [!TIP]
+> If you wonder why `satisfies JSONSchema` instead of `schema: JSONSchema`, check [this Pull Request](https://github.com/cyrilletuzi/angular-async-local-storage/pull/1002).
+
+```ts
+// With typebox library
 import { Type, type Static } from '@sinclair/typebox';
 
 const schema = Type.Object({

--- a/docs/WATCHING.md
+++ b/docs/WATCHING.md
@@ -85,14 +85,14 @@ export class SomeComponent implements OnInit {
 
   ngOnInit(): void {
 
-    const schema: JSONSchema = {
+    const schema = {
       type: 'object',
       properties: {
         hello: { type: 'string' },
         world: { type: 'string' },
       },
       required: ['hello', 'world'],
-    };
+    } satisfies JSONSchema;
 
     this.data$ = this.storageMap.watch<Data>('somekey', schema);
 

--- a/lib/src/lib/storages/storage-map.service.spec.ts
+++ b/lib/src/lib/storages/storage-map.service.spec.ts
@@ -109,6 +109,19 @@ function tests(description: string, localStorageServiceFactory: () => StorageMap
 
       });
 
+      it("prepared schema with satisfies", (done) => {
+
+        const schema = { type: "number" } satisfies JSONSchema;
+
+        storage.get("test", schema).subscribe((_: number | undefined) => {
+
+          expect().nothing();
+          done();
+
+        });
+
+      });
+
     });
 
     describe(`get()`, () => {
@@ -118,7 +131,7 @@ function tests(description: string, localStorageServiceFactory: () => StorageMap
         it("with value", (done) => {
 
           const value = "blue";
-          const schema: JSONSchema = { type: "string" };
+          const schema = { type: "string" } satisfies JSONSchema;
 
           storage.set(key, value, schema).pipe(
             mergeMap(() => storage.get(key, schema))
@@ -135,7 +148,7 @@ function tests(description: string, localStorageServiceFactory: () => StorageMap
         it("empty", (done) => {
 
           const value = "";
-          const schema: JSONSchema = { type: "string" };
+          const schema = { type: "string" } satisfies JSONSchema;
 
           storage.set(key, value, schema).pipe(
             mergeMap(() => storage.get(key, schema))
@@ -152,10 +165,10 @@ function tests(description: string, localStorageServiceFactory: () => StorageMap
         it("const", (done) => {
 
           const value = "hello";
-          const schema: JSONSchema = {
+          const schema = {
             type: "string",
             const: "hello",
-          };
+          } satisfies JSONSchema;
 
           storage.set(key, value, schema).pipe(
             mergeMap(() => storage.get<"hello">(key, schema))
@@ -172,10 +185,10 @@ function tests(description: string, localStorageServiceFactory: () => StorageMap
         it("enum", (done) => {
 
           const value = "world";
-          const schema: JSONSchema = {
+          const schema = {
             type: "string",
             enum: ["hello", "world"],
-          };
+          } satisfies JSONSchema;
 
           storage.set(key, value, schema).pipe(
             mergeMap(() => storage.get<"hello" | "world">(key, schema))
@@ -196,7 +209,7 @@ function tests(description: string, localStorageServiceFactory: () => StorageMap
         it("with value", (done) => {
 
           const value = 1.5;
-          const schema: JSONSchema = { type: "number" };
+          const schema = { type: "number" } satisfies JSONSchema;
 
           storage.set(key, value, schema).pipe(
             mergeMap(() => storage.get(key, schema))
@@ -213,7 +226,7 @@ function tests(description: string, localStorageServiceFactory: () => StorageMap
         it("zero", (done) => {
 
           const value = 0;
-          const schema: JSONSchema = { type: "number" };
+          const schema = { type: "number" } satisfies JSONSchema;
 
           storage.set(key, value, schema).pipe(
             mergeMap(() => storage.get(key, schema))
@@ -230,10 +243,10 @@ function tests(description: string, localStorageServiceFactory: () => StorageMap
         it("const", (done) => {
 
           const value = 1.5;
-          const schema: JSONSchema = {
+          const schema = {
             type: "number",
             const: 1.5,
-          };
+          } satisfies JSONSchema;
 
           storage.set(key, value, schema).pipe(
             mergeMap(() => storage.get<1.5>(key, schema))
@@ -250,10 +263,10 @@ function tests(description: string, localStorageServiceFactory: () => StorageMap
         it("enum", (done) => {
 
           const value = 2.4;
-          const schema: JSONSchema = {
+          const schema = {
             type: "number",
             enum: [1.5, 2.4],
-          };
+          } satisfies JSONSchema;
 
           storage.set(key, value, schema).pipe(
             mergeMap(() => storage.get<1.5 | 2.4>(key, schema))
@@ -274,7 +287,7 @@ function tests(description: string, localStorageServiceFactory: () => StorageMap
         it("with value", (done) => {
 
           const value = 1;
-          const schema: JSONSchema = { type: "integer" };
+          const schema = { type: "integer" } satisfies JSONSchema;
 
           storage.set(key, value, schema).pipe(
             mergeMap(() => storage.get(key, schema))
@@ -291,7 +304,7 @@ function tests(description: string, localStorageServiceFactory: () => StorageMap
         it("zero", (done) => {
 
           const value = 0;
-          const schema: JSONSchema = { type: "integer" };
+          const schema = { type: "integer" } satisfies JSONSchema;
 
           storage.set(key, value, schema).pipe(
             mergeMap(() => storage.get(key, schema))
@@ -308,10 +321,10 @@ function tests(description: string, localStorageServiceFactory: () => StorageMap
         it("const", (done) => {
 
           const value = 1;
-          const schema: JSONSchema = {
+          const schema = {
             type: "integer",
             const: 1,
-          };
+          } satisfies JSONSchema;
 
           storage.set(key, value, schema).pipe(
             mergeMap(() => storage.get<1>(key, schema))
@@ -328,10 +341,10 @@ function tests(description: string, localStorageServiceFactory: () => StorageMap
         it("enum", (done) => {
 
           const value = 2;
-          const schema: JSONSchema = {
+          const schema = {
             type: "integer",
             enum: [1, 2],
-          };
+          } satisfies JSONSchema;
 
           storage.set(key, value, schema).pipe(
             mergeMap(() => storage.get<1 | 2>(key, schema))
@@ -352,7 +365,7 @@ function tests(description: string, localStorageServiceFactory: () => StorageMap
         it("true", (done) => {
 
           const value = true;
-          const schema: JSONSchema = { type: "boolean" };
+          const schema = { type: "boolean" } satisfies JSONSchema;
 
           storage.set(key, value, schema).pipe(
             mergeMap(() => storage.get(key, schema))
@@ -369,7 +382,7 @@ function tests(description: string, localStorageServiceFactory: () => StorageMap
         it("false", (done) => {
 
           const value = false;
-          const schema: JSONSchema = { type: "boolean" };
+          const schema = { type: "boolean" } satisfies JSONSchema;
 
           storage.set(key, value, schema).pipe(
             mergeMap(() => storage.get(key, schema))
@@ -386,10 +399,10 @@ function tests(description: string, localStorageServiceFactory: () => StorageMap
         it("const", (done) => {
 
           const value = true;
-          const schema: JSONSchema = {
+          const schema = {
             type: "boolean",
             const: true,
-          };
+          } satisfies JSONSchema;
 
           storage.set(key, value, schema).pipe(
             mergeMap(() => storage.get<true>(key, schema))
@@ -413,7 +426,7 @@ function tests(description: string, localStorageServiceFactory: () => StorageMap
           const schema = {
             type: "array",
             items: { type: "string" },
-          } as const;
+          } satisfies JSONSchema;
 
           storage.set(key, value, schema).pipe(
             mergeMap(() => storage.get(key, schema))
@@ -433,7 +446,7 @@ function tests(description: string, localStorageServiceFactory: () => StorageMap
           const schema = {
             type: "array",
             items: { type: "integer" },
-          } as const;
+          } satisfies JSONSchema;
 
           storage.set(key, value, schema).pipe(
             mergeMap(() => storage.get(key, schema))
@@ -453,7 +466,7 @@ function tests(description: string, localStorageServiceFactory: () => StorageMap
           const schema = {
             type: "array",
             items: { type: "number" },
-          } as const;
+          } satisfies JSONSchema;
 
           storage.set(key, value, schema).pipe(
             mergeMap(() => storage.get(key, schema))
@@ -473,7 +486,7 @@ function tests(description: string, localStorageServiceFactory: () => StorageMap
           const schema = {
             type: "array",
             items: { type: "boolean" },
-          } as const;
+          } satisfies JSONSchema;
 
           storage.set(key, value, schema).pipe(
             mergeMap(() => storage.get(key, schema))
@@ -490,13 +503,13 @@ function tests(description: string, localStorageServiceFactory: () => StorageMap
         it("of arrays", (done) => {
 
           const value = [["hello", "world"], ["my", "name"], ["is", "Elmo"]];
-          const schema: JSONSchema = {
+          const schema = {
             type: "array",
             items: {
               type: "array",
               items: { type: "string" },
             },
-          };
+          } satisfies JSONSchema;
 
           storage.set(key, value, schema).pipe(
             mergeMap(() => storage.get<string[][]>(key, schema))
@@ -520,7 +533,7 @@ function tests(description: string, localStorageServiceFactory: () => StorageMap
           }, {
             name: "Chester",
           }];
-          const schema: JSONSchema = {
+          const schema = {
             type: "array",
             items: {
               type: "object",
@@ -530,7 +543,7 @@ function tests(description: string, localStorageServiceFactory: () => StorageMap
               },
               required: ["name"],
             },
-          };
+          } satisfies JSONSchema;
 
           storage.set(key, value, schema).pipe(
             mergeMap(() => storage.get<Monster[]>(key, schema))
@@ -552,7 +565,7 @@ function tests(description: string, localStorageServiceFactory: () => StorageMap
             type: "array",
             items: { type: "string" },
             uniqueItems: true,
-          } as const;
+          } satisfies JSONSchema;
 
           storage.set(key, Array.from(value), schema).pipe(
             mergeMap(() => storage.get(key, schema)),
@@ -572,7 +585,7 @@ function tests(description: string, localStorageServiceFactory: () => StorageMap
             name: "Elmo",
             address: "Sesame street",
           }];
-          const schema: JSONSchema = {
+          const schema = {
             type: "array",
             items: [{
               type: "string"
@@ -584,7 +597,7 @@ function tests(description: string, localStorageServiceFactory: () => StorageMap
               },
               required: ["name"],
             }],
-          };
+          } satisfies JSONSchema;
 
           storage.set(key, value, schema).pipe(
             mergeMap(() => storage.get<[string, Monster]>(key, schema))
@@ -610,7 +623,7 @@ function tests(description: string, localStorageServiceFactory: () => StorageMap
             }],
           ];
           const value = new Map<string, Monster>(array);
-          const schema: JSONSchema = {
+          const schema = {
             type: "array",
             items: {
               type: "array",
@@ -625,7 +638,7 @@ function tests(description: string, localStorageServiceFactory: () => StorageMap
                 required: ["name"],
               }],
             },
-          };
+          } satisfies JSONSchema;
 
           storage.set(key, Array.from(value), schema).pipe(
             mergeMap(() => storage.get<[string, Monster][]>(key, schema)),
@@ -667,7 +680,7 @@ function tests(description: string, localStorageServiceFactory: () => StorageMap
               sisters: 3,
             },
           };
-          const schema: JSONSchema = {
+          const schema = {
             type: "object",
             properties: {
               name: { type: "string" },
@@ -688,7 +701,7 @@ function tests(description: string, localStorageServiceFactory: () => StorageMap
               creditCard: { type: "number" },
             },
             required: ["name", "age", "philosopher", "books", "family"],
-          };
+          } satisfies JSONSchema;
 
           storage.set(key, value, schema).pipe(
             mergeMap(() => storage.get<User>(key, schema))
@@ -712,13 +725,13 @@ function tests(description: string, localStorageServiceFactory: () => StorageMap
           const value: User = {
             name: "Henri Bergson",
           };
-          const schema: JSONSchema = {
+          const schema = {
             type: "object",
             properties: {
               name: { type: "string" },
               age: { type: "number" },
             },
-          };
+          } satisfies JSONSchema;
 
           storage.set(key, value, schema).pipe(
             mergeMap(() => storage.get<User>(key, schema))
@@ -775,7 +788,7 @@ function tests(description: string, localStorageServiceFactory: () => StorageMap
 
         it("unexisting key", (done) => {
 
-          const schema: JSONSchema = { type: "string" };
+          const schema = { type: "string" } satisfies JSONSchema;
 
           storage.get(`unknown${Date.now()}`, schema).subscribe((data: string | undefined) => {
 
@@ -789,7 +802,7 @@ function tests(description: string, localStorageServiceFactory: () => StorageMap
 
         it("null", (done) => {
 
-          const schema: JSONSchema = { type: "string" };
+          const schema = { type: "string" } satisfies JSONSchema;
 
           storage.set(key, "test", schema).pipe(
             mergeMap(() => storage.set(key, null, schema)),
@@ -806,7 +819,7 @@ function tests(description: string, localStorageServiceFactory: () => StorageMap
 
         it("undefined", (done) => {
 
-          const schema: JSONSchema = { type: "string" };
+          const schema = { type: "string" } satisfies JSONSchema;
 
           storage.set(key, "test", schema).pipe(
             mergeMap(() => storage.set(key, undefined, schema)),
@@ -885,7 +898,7 @@ function tests(description: string, localStorageServiceFactory: () => StorageMap
             }],
           ];
 
-          const schema: JSONSchema = {
+          const schema = {
             type: "array",
             items: {
               type: "array",
@@ -918,7 +931,7 @@ function tests(description: string, localStorageServiceFactory: () => StorageMap
                 required: ["country", "population", "coordinates"],
               }]
             },
-          };
+          } satisfies JSONSchema;
 
 
           storage.set(key, value, schema).pipe(
@@ -941,7 +954,7 @@ function tests(description: string, localStorageServiceFactory: () => StorageMap
 
       it("update", (done) => {
 
-        const schema: JSONSchema = { type: "string" };
+        const schema = { type: "string" } satisfies JSONSchema;
 
         storage.set(key, "value", schema).pipe(
           mergeMap(() => storage.set(key, "updated", schema))
@@ -959,7 +972,7 @@ function tests(description: string, localStorageServiceFactory: () => StorageMap
 
         const value1 = "test1";
         const value2 = "test2";
-        const schema: JSONSchema = { type: "string" };
+        const schema = { type: "string" } satisfies JSONSchema;
 
         expect(() => {
 
@@ -1147,7 +1160,7 @@ function tests(description: string, localStorageServiceFactory: () => StorageMap
 
         const watchedKey = "watched1";
         const values = [undefined, "test1", undefined, "test2", undefined];
-        const schema: JSONSchema = { type: "string" };
+        const schema = { type: "string" } satisfies JSONSchema;
         let i = 0;
 
         storage.watch(watchedKey, schema).subscribe((result: string | undefined) => {
@@ -1178,7 +1191,7 @@ function tests(description: string, localStorageServiceFactory: () => StorageMap
         expected: string;
       }
 
-      const schema: JSONSchema = {
+      const schema = {
         type: "object",
         properties: {
           expected: {
@@ -1186,12 +1199,12 @@ function tests(description: string, localStorageServiceFactory: () => StorageMap
           }
         },
         required: ["expected"]
-      };
+      } satisfies JSONSchema;
 
       it("valid schema with options", (done) => {
 
         const value = 5;
-        const schemaWithOptions: JSONSchema = { type: "number", maximum: 10 };
+        const schemaWithOptions = { type: "number", maximum: 10 } satisfies JSONSchema;
 
         storage.set(key, value, schemaWithOptions).pipe(
           mergeMap(() => storage.get(key, schemaWithOptions)),
@@ -1208,7 +1221,7 @@ function tests(description: string, localStorageServiceFactory: () => StorageMap
       it("invalid schema with options", (done) => {
 
         const value = 15;
-        const schemaWithOptions: JSONSchema = { type: "number", maximum: 10 };
+        const schemaWithOptions = { type: "number", maximum: 10 } satisfies JSONSchema;
 
         storage.set(key, value, { type: "number" }).pipe(
           mergeMap(() => storage.get(key, schemaWithOptions)),
@@ -1292,7 +1305,7 @@ function tests(description: string, localStorageServiceFactory: () => StorageMap
      * Avoid https://github.com/cyrilletuzi/angular-async-local-storage/issues/5 */
     describe("complete", () => {
 
-      const schema: JSONSchema = { type: "string" };
+      const schema = { type: "string" } satisfies JSONSchema;
 
       it("get()", (done) => {
 
@@ -1594,7 +1607,7 @@ function tests(description: string, localStorageServiceFactory: () => StorageMap
 
     describe("compatibility with Promise", () => {
 
-      const schema: JSONSchema = { type: "string" };
+      const schema = { type: "string" } satisfies JSONSchema;
 
       it("Promise", (done) => {
 

--- a/lib/src/lib/storages/storage-map.service.ts
+++ b/lib/src/lib/storages/storage-map.service.ts
@@ -171,7 +171,7 @@ export class StorageMap {
    *     lastName: { type: 'string' },
    *   },
    *   required: ['firstName'],
-   * };
+   * } satisfies JSONSchema;
    *
    * this.storageMap.get<User>('user', schema).subscribe((user) => {
    *   if (user) {

--- a/lib/src/lib/validation/json-schema.spec.ts
+++ b/lib/src/lib/validation/json-schema.spec.ts
@@ -12,14 +12,14 @@ describe("JSONSchema", () => {
 
     it("string", () => {
 
-      const schema: JSONSchema = {
+      const schema = {
         type: "string",
         const: "hello",
         enum: ["hello", "world"],
         maxLength: 10,
         minLength: 1,
         pattern: "[a-Z]+",
-      };
+      } satisfies JSONSchema;
 
       test(schema);
 
@@ -27,7 +27,7 @@ describe("JSONSchema", () => {
 
     it("number", () => {
 
-      const schema: JSONSchema = {
+      const schema = {
         type: "number",
         const: 1.5,
         enum: [1.5, 2.4],
@@ -36,7 +36,7 @@ describe("JSONSchema", () => {
         exclusiveMinimum: 2.3,
         minimum: 3.1,
         multipleOf: 2.1,
-      };
+      } satisfies JSONSchema;
 
       test(schema);
 
@@ -44,7 +44,7 @@ describe("JSONSchema", () => {
 
     it("integer", () => {
 
-      const schema: JSONSchema = {
+      const schema = {
         type: "integer",
         const: 1,
         enum: [1, 2],
@@ -53,7 +53,7 @@ describe("JSONSchema", () => {
         exclusiveMinimum: 2,
         minimum: 3,
         multipleOf: 2,
-      };
+      } satisfies JSONSchema;
 
       test(schema);
 
@@ -61,10 +61,10 @@ describe("JSONSchema", () => {
 
     it("boolean", () => {
 
-      const schema: JSONSchema = {
+      const schema = {
         type: "boolean",
         const: true,
-      };
+      } satisfies JSONSchema;
 
       test(schema);
 
@@ -72,13 +72,13 @@ describe("JSONSchema", () => {
 
     it("array", () => {
 
-      const schema: JSONSchema = {
+      const schema = {
         type: "array",
         items: { type: "string" },
         maxItems: 10,
         minItems: 1,
         uniqueItems: true,
-      };
+      } satisfies JSONSchema;
 
       test(schema);
 
@@ -86,7 +86,7 @@ describe("JSONSchema", () => {
 
     it("tuple", () => {
 
-      const schema: JSONSchema = {
+      const schema = {
         type: "array",
         items: [
           { type: "string" },
@@ -95,7 +95,7 @@ describe("JSONSchema", () => {
         maxItems: 2,
         minItems: 2,
         uniqueItems: true,
-      };
+      } satisfies JSONSchema;
 
       test(schema);
 
@@ -103,14 +103,14 @@ describe("JSONSchema", () => {
 
     it("object", () => {
 
-      const schema: JSONSchema = {
+      const schema = {
         type: "object",
         properties: {
           hello: { type: "string" },
           world: { type: "number" },
         },
         required: ["hello"],
-      };
+      } satisfies JSONSchema;
 
       test(schema);
 
@@ -125,7 +125,7 @@ describe("JSONSchema", () => {
       const schema = {
         type: "string",
         enum: ["hello", "world"],
-      } as const;
+      } as const satisfies JSONSchema;
 
       test(schema);
 
@@ -136,7 +136,7 @@ describe("JSONSchema", () => {
       const schema = {
         type: "number",
         enum: [1.4, 2.6],
-      } as const;
+      } as const satisfies JSONSchema;
 
       test(schema);
 
@@ -147,7 +147,7 @@ describe("JSONSchema", () => {
       const schema = {
         type: "integer",
         enum: [1, 2],
-      } as const;
+      } as const satisfies JSONSchema;
 
       test(schema);
 
@@ -161,7 +161,7 @@ describe("JSONSchema", () => {
           { type: "string" },
           { type: "number" },
         ],
-      } as const;
+      } as const satisfies JSONSchema;
 
       test(schema);
 
@@ -176,7 +176,7 @@ describe("JSONSchema", () => {
           world: { type: "number" },
         },
         required: ["hello"],
-      } as const;
+      } as const satisfies JSONSchema;
 
       test(schema);
 
@@ -188,11 +188,11 @@ describe("JSONSchema", () => {
 
     it("unexisting option", () => {
 
-      const schema: JSONSchema = {
+      const schema = {
         type: "string",
         // @ts-expect-error Failure test
         required: ["hello"],
-      };
+      } satisfies JSONSchema;
 
       test(schema);
 
@@ -200,24 +200,13 @@ describe("JSONSchema", () => {
 
     it("option with wrong type", () => {
 
-      const schema: JSONSchema = {
+      const schema = {
         type: "string",
         // @ts-expect-error Failure test
         maxLength: "1",
-      };
+      } satisfies JSONSchema;
 
-      test(schema);
-
-    });
-
-    it("option with wrong type", () => {
-
-      const schema: JSONSchema = {
-        type: "string",
-        // @ts-expect-error Failure test
-        maxLength: "1",
-      };
-
+      // @ts-expect-error Failure test
       test(schema);
 
     });

--- a/lib/src/lib/validation/json-schema.ts
+++ b/lib/src/lib/validation/json-schema.ts
@@ -292,31 +292,31 @@ export interface JSONSchemaObject {
  * @see {@link https://github.com/cyrilletuzi/angular-async-local-storage/blob/main/docs/VALIDATION.md}
  *
  * @example
- * const schema: JSONSchema = { type: 'string' };
+ * const schema = { type: 'string' } satisfies JSONSchema;
  *
  * @example
- * const schema: JSONSchema = { type: 'number' };
+ * const schema = { type: 'number' } satisfies JSONSchema;
  *
  * @example
- * const schema: JSONSchema = { type: 'integer' };
+ * const schema = { type: 'integer' } satisfies JSONSchema;
  *
  * @example
- * const schema: JSONSchema = { type: 'boolean' };
+ * const schema = { type: 'boolean' } satisfies JSONSchema;
  *
  * @example
- * const schema: JSONSchema = {
+ * const schema = {
  *   type: 'array',
  *   items: { type: 'string' },
- * };
+ * } satisfies JSONSchema;
  *
  * @example
- * const schema: JSONSchema = {
+ * const schema = {
  *   type: 'object',
  *   properties: {
  *     firstName: { type: 'string' },
  *     lastName: { type: 'string' },
  *   },
  *   required: ['firstName'],
- * };
+ * } satisfies JSONSchema;
  */
 export type JSONSchema = JSONSchemaString | JSONSchemaNumber | JSONSchemaInteger | JSONSchemaBoolean | JSONSchemaArray | JSONSchemaTuple | JSONSchemaObject;

--- a/lib/src/lib/validation/json-validation.spec.ts
+++ b/lib/src/lib/validation/json-validation.spec.ts
@@ -1,3 +1,4 @@
+import type { JSONSchema } from "./json-schema";
 import { JSONValidator } from "./json-validator";
 
 describe(`JSONValidator`, () => {
@@ -101,7 +102,7 @@ describe(`JSONValidator`, () => {
 
       it("special case: readonly", () => {
 
-        const schema = { type: "string", enum: ["", "hello"] } as const;
+        const schema = { type: "string", enum: ["", "hello"] }  satisfies JSONSchema;
 
         const test = jsonValidator.validate("", schema);
 

--- a/testing-apps/demo/src/app/app.component.ts
+++ b/testing-apps/demo/src/app/app.component.ts
@@ -62,13 +62,13 @@ export class AppComponent implements OnInit {
 
   ngOnInit(): void {
 
-    const schema: JSONSchema = {
+    const schema = {
       type: "object",
       properties: {
         title: { type: "string" },
       },
       required: ["title"],
-    };
+    } satisfies JSONSchema;
 
     this.storageMap.set("clear", "test").pipe(
       mergeMap(() => this.storageMap.clear()),

--- a/testing-apps/iframe/src/app/app.component.ts
+++ b/testing-apps/iframe/src/app/app.component.ts
@@ -30,14 +30,14 @@ export class AppComponent implements OnInit {
   ngOnInit(): void {
 
     const key = "test";
-    const schema: JSONSchema = {
+    const schema = {
       type: "object",
       properties: {
         title: {
           type: "string"
         }
       }
-    };
+    } satisfies JSONSchema;
 
     this.data$ = this.storageMap.set(key, { title: this.title }).pipe(
       switchMap(() => this.storageMap.get<Data>(key, schema))


### PR DESCRIPTION
TypeScript 4.9 introduced `satisfies`, which solves an old typing pain point for `JSONSchema`. Refer to the [TypeScript documentation](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-9.html#the-satisfies-operator) for an explanation.

Note it is just a documentation change, direct typing still works.

Below is an example from this library of the difference between direct typing and `satisfies`:

```ts
const schema1 = {
  type: "object",
  properties: {
    title: { type: "string" },
  },
  required: ["title"],
} satisfies JSONSchema;

schema1.properties.title; // OK!

const schema2: JSONSchema = {
  type: "object",
  properties: {
    title: { type: "string" },
  },
  required: ["title"],
};

schema2.properties.title; // Not OK
schema2.properties["title"]?.type; // OK, but type includes `undefined`
```

Note that there is still some type widening happening. The best solution would be:

```ts
const schema = {
  type: "object",
  properties: {
    title: { type: "string" },
  },
  required: ["title"],
} as const satisfies JSONSchema;
```

Thus the schema is kept fully intact, without any type widening, while still having autocomplete and type check.